### PR TITLE
(refactor) un-require .jsx extension on imports

### DIFF
--- a/client/app/components/Body.jsx
+++ b/client/app/components/Body.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 
-import Chart from './Chart.jsx';
-import Input from './Input.jsx';
+import Chart from './Chart';
+import Input from './Input';
 
 export default class Body extends React.Component {
   render () {

--- a/client/app/components/Layout.jsx
+++ b/client/app/components/Layout.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import Body from './Body.jsx'
-import Footer from './Footer.jsx';
-import Header from './Header.jsx';
+import Body from './Body'
+import Footer from './Footer';
+import Header from './Header';
 
 export default class Layout extends React.Component {
   render () {

--- a/client/app/index.jsx
+++ b/client/app/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {render} from 'react-dom';
-import Layout from './components/Layout.jsx'
+import Layout from './components/Layout'
 
 class App extends React.Component {
   render () {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,9 @@ var config = {
        loader : 'babel-loader'
      }
    ]
+ },
+ resolve: {
+  extensions: ['.js', '.json', '.jsx']
  }
 };
 


### PR DESCRIPTION
🐬  After merging this, we won't need to add `.jsx` extensions when importing components 

