### PR TITLE
(bug) inherit env variables from staging app

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,6 +3,12 @@
   "scripts": {
   },
   "env": {
+    "AYLIEN_ID": {
+      "required": true
+    },
+    "AYLIEN_KEY": {
+      "required": true
+    }
   },
   "formation": {
   },

--- a/integration-tests/aylienApi.spec.js
+++ b/integration-tests/aylienApi.spec.js
@@ -7,13 +7,17 @@ const expect = chai.expect;
 const apiInstance = new AylienNewsApi.DefaultApi();
 
 try {
-  const apiInfo = require('../lib/env/aylienApiKeys');
+  try {
+    const apiInfo = require('../lib/env/aylienApiKeys');
+  } catch (e) {
+    const apiInfo = {};
+  }
 
   let appId = apiInstance.apiClient.authentications['app_id'];
-  appId.apiKey = apiInfo.id;
+  appId.apiKey = AYLIEN_ID || apiInfo.id;
 
   let appKey = apiInstance.apiClient.authentications['app_key'];
-  appKey.apiKey = apiInfo.key;
+  appKey.apiKey = AYLIEN_KEY || apiInfo.key;
 } catch (e) {
   console.log(e);
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "sinon": "^2.1.0",
-    "supertest": "^3.0.0"
+    "supertest": "^3.0.0",
+    "webpack": "^2.5.0"
   },
   "engines": {
     "node": "7.9.0"


### PR DESCRIPTION
This should (I think) set our test apps to inherit their config vars from the staging/deployed app.  That will prevent me from needing to input them manually each time we make a test app.