### PR TITLE
Feat/stitch timeline

### DIFF
--- a/integration-tests/fixtures/stitched-timeline.js
+++ b/integration-tests/fixtures/stitched-timeline.js
@@ -1,0 +1,418 @@
+module.exports = [
+  {
+    'time': 1454198400,
+    'formattedTime': 'Jan 31 - Feb 6 2016',
+    'formattedAxisTime': 'Jan 31, 2016',
+    'popularity': 33
+  },
+  {
+    'time': 1454803200,
+    'formattedTime': 'Feb 7 - Feb 13 2016',
+    'formattedAxisTime': 'Feb 7, 2016',
+    'popularity': 38
+  },
+  {
+    'time': 1455408000,
+    'formattedTime': 'Feb 14 - Feb 20 2016',
+    'formattedAxisTime': 'Feb 14, 2016',
+    'popularity': 34
+  },
+  {
+    'time': 1456012800,
+    'formattedTime': 'Feb 21 - Feb 27 2016',
+    'formattedAxisTime': 'Feb 21, 2016',
+    'popularity': 33
+  },
+  {
+    'time': 1456617600,
+    'formattedTime': 'Feb 28 - Mar 5 2016',
+    'formattedAxisTime': 'Feb 28, 2016',
+    'popularity': 33
+  },
+  {
+    'time': 1457222400,
+    'formattedTime': 'Mar 6 - Mar 12 2016',
+    'formattedAxisTime': 'Mar 6, 2016',
+    'popularity': 33
+  },
+  {
+    'time': 1457827200,
+    'formattedTime': 'Mar 13 - Mar 19 2016',
+    'formattedAxisTime': 'Mar 13, 2016',
+    'popularity': 35
+  },
+  {
+    'time': 1458432000,
+    'formattedTime': 'Mar 20 - Mar 26 2016',
+    'formattedAxisTime': 'Mar 20, 2016',
+    'popularity': 35
+  },
+  {
+    'time': 1459036800,
+    'formattedTime': 'Mar 27 - Apr 2 2016',
+    'formattedAxisTime': 'Mar 27, 2016',
+    'popularity': 36
+  },
+  {
+    'time': 1459641600,
+    'formattedTime': 'Apr 3 - Apr 9 2016',
+    'formattedAxisTime': 'Apr 3, 2016',
+    'popularity': 34
+  },
+  {
+    'time': 1460246400,
+    'formattedTime': 'Apr 10 - Apr 16 2016',
+    'formattedAxisTime': 'Apr 10, 2016',
+    'popularity': 38
+  },
+  {
+    'time': 1460851200,
+    'formattedTime': 'Apr 17 - Apr 23 2016',
+    'formattedAxisTime': 'Apr 17, 2016',
+    'popularity': 38
+  },
+  {
+    'time': 1461456000,
+    'formattedTime': 'Apr 24 - Apr 30 2016',
+    'formattedAxisTime': 'Apr 24, 2016',
+    'popularity': 38
+  },
+  {
+    'time': 1462060800,
+    'formattedTime': 'May 1 - May 7 2016',
+    'formattedAxisTime': 'May 1, 2016',
+    'popularity': 44
+  },
+  {
+    'time': 1462665600,
+    'formattedTime': 'May 8 - May 14 2016',
+    'formattedAxisTime': 'May 8, 2016',
+    'popularity': 52
+  },
+  {
+    'time': 1463270400,
+    'formattedTime': 'May 15 - May 21 2016',
+    'formattedAxisTime': 'May 15, 2016',
+    'popularity': 48
+  },
+  {
+    'time': 1463875200,
+    'formattedTime': 'May 22 - May 28 2016',
+    'formattedAxisTime': 'May 22, 2016',
+    'popularity': 62
+  },
+  {
+    'time': 1464480000,
+    'formattedTime': 'May 29 - Jun 4 2016',
+    'formattedAxisTime': 'May 29, 2016',
+    'popularity': 100,
+    'stories': [
+      {
+        headline: 'Clinton means continuity for US economy, Trump the unknown',
+        url: 'https://sg.news.yahoo.com/clinton-means-continuity-us-economy-trump-unknown-035116733.html',
+        media: 'https://s.yimg.com/uu/api/res/1.2/zXhKW.ZkLsbBHxj7yHyVLw--/aD01MTI7dz03Njg7c209MTthcHBpZD15dGFjaHlvbg--/http://media.zenfs.com/en_sg/News/AFP/a564487a19c3f06473de5b5802c81770b5f19040.jpg',
+        summary: 'Survey by the CNBC network of economists and Wall Street participants showed 46% feel Donald Trump would be better for the economy compared to 39% favoring Hillary Clinton\n\nOn taxes, public spending and protectionism the two candidates for the White House are diametrically opposed: Hillary Clinton represents continuity while Donald Trump seduces or frightens with his radical proposals.'
+      },
+      {
+        headline: 'Clinton leads Trump 48-43 percent in Washington Post - ABC tracking poll',
+        url: 'https://sg.news.yahoo.com/clinton-leads-trump-48-43-pct-washington-post-043905727.html',
+        media: 'https://s.yimg.com/ny/api/res/1.2/hmD7X8.fZspw61WBUzbvpQ--/YXBwaWQ9aGlnaGxhbmRlcjtzbT0xO3c9NDUwO2g9MzAwO2lsPXBsYW5l/http://media.zenfs.com/en_us/News/Reuters/2016-11-06T043905Z_1_LYNXMPECA5041_RTROPTP_2_USA-ELECTION-CLINTON.JPG.cf.jpg',
+        summary: 'U.S. Democratic presidential nominee Hillary Clinton rides an elevator with aides as she arrives for a campaign concert with Katy Perry in Philadelphia, Pennsylvania, U.S. November 5, 2016.'
+      },
+      {
+        headline: 'Clinton leads Trump 48-43 percent in Washington Post-ABC tracking poll',
+        url: 'http://news.yahoo.com/clinton-leads-trump-48-43-percent-washington-post-043628359.html',
+        media: 'https://s.yimg.com/os/mit/media/m/social/images/social_default_logo-1481777.png',
+        summary: 'U.S. presidential candidates Donald Trump and Hillary Clinton attend campaign rallies in Ambridge, Pennsylvania, October 10, 2016 and Manchester, New Hampshire U.S., October 24, 2016 in a combination of file photos.'
+      },
+      {
+        headline: 'Trump, Clinton take different strategies to shore up votes',
+        url: 'http://news.yahoo.com/trump-clinton-different-strategies-shore-votes-074124539--election.html',
+        media: 'https://s.yimg.com/uu/api/res/1.2/pGpymPAnre4DU70qrzucUQ--/aD0xMDgwO3c9MTkyMDtzbT0xO2FwcGlkPXl0YWNoeW9u/http://media.zenfs.com/en-US/video/video.associatedpressfree.com/0356d465b3c790fbd9745e29776ac563',
+        summary: 'Hillary Clinton is focusing her efforts in the campaign\'s final days on energizing voters who usually support the Democratic nominee, but may need an extra boost.'
+      }
+    ]
+  },
+  {
+    'time': 1465084800,
+    'formattedTime': 'Jun 5 - Jun 11 2016',
+    'formattedAxisTime': 'Jun 5, 2016',
+    'popularity': 96
+  },
+  {
+    'time': 1465689600,
+    'formattedTime': 'Jun 12 - Jun 18 2016',
+    'formattedAxisTime': 'Jun 12, 2016',
+    'popularity': 71
+  },
+  {
+    'time': 1466294400,
+    'formattedTime': 'Jun 19 - Jun 25 2016',
+    'formattedAxisTime': 'Jun 19, 2016',
+    'popularity': 56
+  },
+  {
+    'time': 1466899200,
+    'formattedTime': 'Jun 26 - Jul 2 2016',
+    'formattedAxisTime': 'Jun 26, 2016',
+    'popularity': 52
+  },
+  {
+    'time': 1467504000,
+    'formattedTime': 'Jul 3 - Jul 9 2016',
+    'formattedAxisTime': 'Jul 3, 2016',
+    'popularity': 48
+  },
+  {
+    'time': 1468108800,
+    'formattedTime': 'Jul 10 - Jul 16 2016',
+    'formattedAxisTime': 'Jul 10, 2016',
+    'popularity': 44
+  },
+  {
+    'time': 1468713600,
+    'formattedTime': 'Jul 17 - Jul 23 2016',
+    'formattedAxisTime': 'Jul 17, 2016',
+    'popularity': 42
+  },
+  {
+    'time': 1469318400,
+    'formattedTime': 'Jul 24 - Jul 30 2016',
+    'formattedAxisTime': 'Jul 24, 2016',
+    'popularity': 42
+  },
+  {
+    'time': 1469923200,
+    'formattedTime': 'Jul 31 - Aug 6 2016',
+    'formattedAxisTime': 'Jul 31, 2016',
+    'popularity': 40
+  },
+  {
+    'time': 1470528000,
+    'formattedTime': 'Aug 7 - Aug 13 2016',
+    'formattedAxisTime': 'Aug 7, 2016',
+    'popularity': 40
+  },
+  {
+    'time': 1471132800,
+    'formattedTime': 'Aug 14 - Aug 20 2016',
+    'formattedAxisTime': 'Aug 14, 2016',
+    'popularity': 40
+  },
+  {
+    'time': 1471737600,
+    'formattedTime': 'Aug 21 - Aug 27 2016',
+    'formattedAxisTime': 'Aug 21, 2016',
+    'popularity': 37
+  },
+  {
+    'time': 1472342400,
+    'formattedTime': 'Aug 28 - Sep 3 2016',
+    'formattedAxisTime': 'Aug 28, 2016',
+    'popularity': 49
+  },
+  {
+    'time': 1472947200,
+    'formattedTime': 'Sep 4 - Sep 10 2016',
+    'formattedAxisTime': 'Sep 4, 2016',
+    'popularity': 49
+  },
+  {
+    'time': 1473552000,
+    'formattedTime': 'Sep 11 - Sep 17 2016',
+    'formattedAxisTime': 'Sep 11, 2016',
+    'popularity': 46
+  },
+  {
+    'time': 1474156800,
+    'formattedTime': 'Sep 18 - Sep 24 2016',
+    'formattedAxisTime': 'Sep 18, 2016',
+    'popularity': 52
+  },
+  {
+    'time': 1474761600,
+    'formattedTime': 'Sep 25 - Oct 1 2016',
+    'formattedAxisTime': 'Sep 25, 2016',
+    'popularity': 43
+  },
+  {
+    'time': 1475366400,
+    'formattedTime': 'Oct 2 - Oct 8 2016',
+    'formattedAxisTime': 'Oct 2, 2016',
+    'popularity': 38
+  },
+  {
+    'time': 1475971200,
+    'formattedTime': 'Oct 9 - Oct 15 2016',
+    'formattedAxisTime': 'Oct 9, 2016',
+    'popularity': 37
+  },
+  {
+    'time': 1476576000,
+    'formattedTime': 'Oct 16 - Oct 22 2016',
+    'formattedAxisTime': 'Oct 16, 2016',
+    'popularity': 35
+  },
+  {
+    'time': 1477180800,
+    'formattedTime': 'Oct 23 - Oct 29 2016',
+    'formattedAxisTime': 'Oct 23, 2016',
+    'popularity': 37
+  },
+  {
+    'time': 1477785600,
+    'formattedTime': 'Oct 30 - Nov 5 2016',
+    'formattedAxisTime': 'Oct 30, 2016',
+    'popularity': 36
+  },
+  {
+    'time': 1478390400,
+    'formattedTime': 'Nov 6 - Nov 12 2016',
+    'formattedAxisTime': 'Nov 6, 2016',
+    'popularity': 31
+  },
+  {
+    'time': 1478995200,
+    'formattedTime': 'Nov 13 - Nov 19 2016',
+    'formattedAxisTime': 'Nov 13, 2016',
+    'popularity': 32
+  },
+  {
+    'time': 1479600000,
+    'formattedTime': 'Nov 20 - Nov 26 2016',
+    'formattedAxisTime': 'Nov 20, 2016',
+    'popularity': 32
+  },
+  {
+    'time': 1480204800,
+    'formattedTime': 'Nov 27 - Dec 3 2016',
+    'formattedAxisTime': 'Nov 27, 2016',
+    'popularity': 32
+  },
+  {
+    'time': 1480809600,
+    'formattedTime': 'Dec 4 - Dec 10 2016',
+    'formattedAxisTime': 'Dec 4, 2016',
+    'popularity': 33
+  },
+  {
+    'time': 1481414400,
+    'formattedTime': 'Dec 11 - Dec 17 2016',
+    'formattedAxisTime': 'Dec 11, 2016',
+    'popularity': 34
+  },
+  {
+    'time': 1482019200,
+    'formattedTime': 'Dec 18 - Dec 24 2016',
+    'formattedAxisTime': 'Dec 18, 2016',
+    'popularity': 33
+  },
+  {
+    'time': 1482624000,
+    'formattedTime': 'Dec 25 - Dec 31 2016',
+    'formattedAxisTime': 'Dec 25, 2016',
+    'popularity': 31
+  },
+  {
+    'time': 1483228800,
+    'formattedTime': 'Jan 1 - Jan 7 2017',
+    'formattedAxisTime': 'Jan 1, 2017',
+    'popularity': 31
+  },
+  {
+    'time': 1483833600,
+    'formattedTime': 'Jan 8 - Jan 14 2017',
+    'formattedAxisTime': 'Jan 8, 2017',
+    'popularity': 29
+  },
+  {
+    'time': 1484438400,
+    'formattedTime': 'Jan 15 - Jan 21 2017',
+    'formattedAxisTime': 'Jan 15, 2017',
+    'popularity': 28
+  },
+  {
+    'time': 1485043200,
+    'formattedTime': 'Jan 22 - Jan 28 2017',
+    'formattedAxisTime': 'Jan 22, 2017',
+    'popularity': 28
+  },
+  {
+    'time': 1485648000,
+    'formattedTime': 'Jan 29 - Feb 4 2017',
+    'formattedAxisTime': 'Jan 29, 2017',
+    'popularity': 28
+  },
+  {
+    'time': 1486252800,
+    'formattedTime': 'Feb 5 - Feb 11 2017',
+    'formattedAxisTime': 'Feb 5, 2017',
+    'popularity': 29
+  },
+  {
+    'time': 1486857600,
+    'formattedTime': 'Feb 12 - Feb 18 2017',
+    'formattedAxisTime': 'Feb 12, 2017',
+    'popularity': 30
+  },
+  {
+    'time': 1487462400,
+    'formattedTime': 'Feb 19 - Feb 25 2017',
+    'formattedAxisTime': 'Feb 19, 2017',
+    'popularity': 32
+  },
+  {
+    'time': 1488067200,
+    'formattedTime': 'Feb 26 - Mar 4 2017',
+    'formattedAxisTime': 'Feb 26, 2017',
+    'popularity': 33
+  },
+  {
+    'time': 1488672000,
+    'formattedTime': 'Mar 5 - Mar 11 2017',
+    'formattedAxisTime': 'Mar 5, 2017',
+    'popularity': 31
+  },
+  {
+    'time': 1489276800,
+    'formattedTime': 'Mar 12 - Mar 18 2017',
+    'formattedAxisTime': 'Mar 12, 2017',
+    'popularity': 30
+  },
+  {
+    'time': 1489881600,
+    'formattedTime': 'Mar 19 - Mar 25 2017',
+    'formattedAxisTime': 'Mar 19, 2017',
+    'popularity': 31
+  },
+  {
+    'time': 1490486400,
+    'formattedTime': 'Mar 26 - Apr 1 2017',
+    'formattedAxisTime': 'Mar 26, 2017',
+    'popularity': 32
+  },
+  {
+    'time': 1491091200,
+    'formattedTime': 'Apr 2 - Apr 8 2017',
+    'formattedAxisTime': 'Apr 2, 2017',
+    'popularity': 30
+  },
+  {
+    'time': 1491696000,
+    'formattedTime': 'Apr 9 - Apr 15 2017',
+    'formattedAxisTime': 'Apr 9, 2017',
+    'popularity': 30
+  },
+  {
+    'time': 1492300800,
+    'formattedTime': 'Apr 16 - Apr 22 2017',
+    'formattedAxisTime': 'Apr 16, 2017',
+    'popularity': 30
+  },
+  {
+    'time': 1492905600,
+    'formattedTime': 'Apr 23 - Apr 29 2017',
+    'formattedAxisTime': 'Apr 23, 2017',
+    'popularity': 31
+  }
+];

--- a/integration-tests/fixtures/stitched-timeline.js
+++ b/integration-tests/fixtures/stitched-timeline.js
@@ -1,108 +1,108 @@
 module.exports = [
   {
-    'time': 1454198400,
+    'date': 1454198400,
     'formattedTime': 'Jan 31 - Feb 6 2016',
     'formattedAxisTime': 'Jan 31, 2016',
     'popularity': 33
   },
   {
-    'time': 1454803200,
+    'date': 1454803200,
     'formattedTime': 'Feb 7 - Feb 13 2016',
     'formattedAxisTime': 'Feb 7, 2016',
     'popularity': 38
   },
   {
-    'time': 1455408000,
+    'date': 1455408000,
     'formattedTime': 'Feb 14 - Feb 20 2016',
     'formattedAxisTime': 'Feb 14, 2016',
     'popularity': 34
   },
   {
-    'time': 1456012800,
+    'date': 1456012800,
     'formattedTime': 'Feb 21 - Feb 27 2016',
     'formattedAxisTime': 'Feb 21, 2016',
     'popularity': 33
   },
   {
-    'time': 1456617600,
+    'date': 1456617600,
     'formattedTime': 'Feb 28 - Mar 5 2016',
     'formattedAxisTime': 'Feb 28, 2016',
     'popularity': 33
   },
   {
-    'time': 1457222400,
+    'date': 1457222400,
     'formattedTime': 'Mar 6 - Mar 12 2016',
     'formattedAxisTime': 'Mar 6, 2016',
     'popularity': 33
   },
   {
-    'time': 1457827200,
+    'date': 1457827200,
     'formattedTime': 'Mar 13 - Mar 19 2016',
     'formattedAxisTime': 'Mar 13, 2016',
     'popularity': 35
   },
   {
-    'time': 1458432000,
+    'date': 1458432000,
     'formattedTime': 'Mar 20 - Mar 26 2016',
     'formattedAxisTime': 'Mar 20, 2016',
     'popularity': 35
   },
   {
-    'time': 1459036800,
+    'date': 1459036800,
     'formattedTime': 'Mar 27 - Apr 2 2016',
     'formattedAxisTime': 'Mar 27, 2016',
     'popularity': 36
   },
   {
-    'time': 1459641600,
+    'date': 1459641600,
     'formattedTime': 'Apr 3 - Apr 9 2016',
     'formattedAxisTime': 'Apr 3, 2016',
     'popularity': 34
   },
   {
-    'time': 1460246400,
+    'date': 1460246400,
     'formattedTime': 'Apr 10 - Apr 16 2016',
     'formattedAxisTime': 'Apr 10, 2016',
     'popularity': 38
   },
   {
-    'time': 1460851200,
+    'date': 1460851200,
     'formattedTime': 'Apr 17 - Apr 23 2016',
     'formattedAxisTime': 'Apr 17, 2016',
     'popularity': 38
   },
   {
-    'time': 1461456000,
+    'date': 1461456000,
     'formattedTime': 'Apr 24 - Apr 30 2016',
     'formattedAxisTime': 'Apr 24, 2016',
     'popularity': 38
   },
   {
-    'time': 1462060800,
+    'date': 1462060800,
     'formattedTime': 'May 1 - May 7 2016',
     'formattedAxisTime': 'May 1, 2016',
     'popularity': 44
   },
   {
-    'time': 1462665600,
+    'date': 1462665600,
     'formattedTime': 'May 8 - May 14 2016',
     'formattedAxisTime': 'May 8, 2016',
     'popularity': 52
   },
   {
-    'time': 1463270400,
+    'date': 1463270400,
     'formattedTime': 'May 15 - May 21 2016',
     'formattedAxisTime': 'May 15, 2016',
     'popularity': 48
   },
   {
-    'time': 1463875200,
+    'date': 1463875200,
     'formattedTime': 'May 22 - May 28 2016',
     'formattedAxisTime': 'May 22, 2016',
     'popularity': 62
   },
   {
-    'time': 1464480000,
+    'date': 1464480000,
     'formattedTime': 'May 29 - Jun 4 2016',
     'formattedAxisTime': 'May 29, 2016',
     'popularity': 100,
@@ -134,283 +134,283 @@ module.exports = [
     ]
   },
   {
-    'time': 1465084800,
+    'date': 1465084800,
     'formattedTime': 'Jun 5 - Jun 11 2016',
     'formattedAxisTime': 'Jun 5, 2016',
     'popularity': 96
   },
   {
-    'time': 1465689600,
+    'date': 1465689600,
     'formattedTime': 'Jun 12 - Jun 18 2016',
     'formattedAxisTime': 'Jun 12, 2016',
     'popularity': 71
   },
   {
-    'time': 1466294400,
+    'date': 1466294400,
     'formattedTime': 'Jun 19 - Jun 25 2016',
     'formattedAxisTime': 'Jun 19, 2016',
     'popularity': 56
   },
   {
-    'time': 1466899200,
+    'date': 1466899200,
     'formattedTime': 'Jun 26 - Jul 2 2016',
     'formattedAxisTime': 'Jun 26, 2016',
     'popularity': 52
   },
   {
-    'time': 1467504000,
+    'date': 1467504000,
     'formattedTime': 'Jul 3 - Jul 9 2016',
     'formattedAxisTime': 'Jul 3, 2016',
     'popularity': 48
   },
   {
-    'time': 1468108800,
+    'date': 1468108800,
     'formattedTime': 'Jul 10 - Jul 16 2016',
     'formattedAxisTime': 'Jul 10, 2016',
     'popularity': 44
   },
   {
-    'time': 1468713600,
+    'date': 1468713600,
     'formattedTime': 'Jul 17 - Jul 23 2016',
     'formattedAxisTime': 'Jul 17, 2016',
     'popularity': 42
   },
   {
-    'time': 1469318400,
+    'date': 1469318400,
     'formattedTime': 'Jul 24 - Jul 30 2016',
     'formattedAxisTime': 'Jul 24, 2016',
     'popularity': 42
   },
   {
-    'time': 1469923200,
+    'date': 1469923200,
     'formattedTime': 'Jul 31 - Aug 6 2016',
     'formattedAxisTime': 'Jul 31, 2016',
     'popularity': 40
   },
   {
-    'time': 1470528000,
+    'date': 1470528000,
     'formattedTime': 'Aug 7 - Aug 13 2016',
     'formattedAxisTime': 'Aug 7, 2016',
     'popularity': 40
   },
   {
-    'time': 1471132800,
+    'date': 1471132800,
     'formattedTime': 'Aug 14 - Aug 20 2016',
     'formattedAxisTime': 'Aug 14, 2016',
     'popularity': 40
   },
   {
-    'time': 1471737600,
+    'date': 1471737600,
     'formattedTime': 'Aug 21 - Aug 27 2016',
     'formattedAxisTime': 'Aug 21, 2016',
     'popularity': 37
   },
   {
-    'time': 1472342400,
+    'date': 1472342400,
     'formattedTime': 'Aug 28 - Sep 3 2016',
     'formattedAxisTime': 'Aug 28, 2016',
     'popularity': 49
   },
   {
-    'time': 1472947200,
+    'date': 1472947200,
     'formattedTime': 'Sep 4 - Sep 10 2016',
     'formattedAxisTime': 'Sep 4, 2016',
     'popularity': 49
   },
   {
-    'time': 1473552000,
+    'date': 1473552000,
     'formattedTime': 'Sep 11 - Sep 17 2016',
     'formattedAxisTime': 'Sep 11, 2016',
     'popularity': 46
   },
   {
-    'time': 1474156800,
+    'date': 1474156800,
     'formattedTime': 'Sep 18 - Sep 24 2016',
     'formattedAxisTime': 'Sep 18, 2016',
     'popularity': 52
   },
   {
-    'time': 1474761600,
+    'date': 1474761600,
     'formattedTime': 'Sep 25 - Oct 1 2016',
     'formattedAxisTime': 'Sep 25, 2016',
     'popularity': 43
   },
   {
-    'time': 1475366400,
+    'date': 1475366400,
     'formattedTime': 'Oct 2 - Oct 8 2016',
     'formattedAxisTime': 'Oct 2, 2016',
     'popularity': 38
   },
   {
-    'time': 1475971200,
+    'date': 1475971200,
     'formattedTime': 'Oct 9 - Oct 15 2016',
     'formattedAxisTime': 'Oct 9, 2016',
     'popularity': 37
   },
   {
-    'time': 1476576000,
+    'date': 1476576000,
     'formattedTime': 'Oct 16 - Oct 22 2016',
     'formattedAxisTime': 'Oct 16, 2016',
     'popularity': 35
   },
   {
-    'time': 1477180800,
+    'date': 1477180800,
     'formattedTime': 'Oct 23 - Oct 29 2016',
     'formattedAxisTime': 'Oct 23, 2016',
     'popularity': 37
   },
   {
-    'time': 1477785600,
+    'date': 1477785600,
     'formattedTime': 'Oct 30 - Nov 5 2016',
     'formattedAxisTime': 'Oct 30, 2016',
     'popularity': 36
   },
   {
-    'time': 1478390400,
+    'date': 1478390400,
     'formattedTime': 'Nov 6 - Nov 12 2016',
     'formattedAxisTime': 'Nov 6, 2016',
     'popularity': 31
   },
   {
-    'time': 1478995200,
+    'date': 1478995200,
     'formattedTime': 'Nov 13 - Nov 19 2016',
     'formattedAxisTime': 'Nov 13, 2016',
     'popularity': 32
   },
   {
-    'time': 1479600000,
+    'date': 1479600000,
     'formattedTime': 'Nov 20 - Nov 26 2016',
     'formattedAxisTime': 'Nov 20, 2016',
     'popularity': 32
   },
   {
-    'time': 1480204800,
+    'date': 1480204800,
     'formattedTime': 'Nov 27 - Dec 3 2016',
     'formattedAxisTime': 'Nov 27, 2016',
     'popularity': 32
   },
   {
-    'time': 1480809600,
+    'date': 1480809600,
     'formattedTime': 'Dec 4 - Dec 10 2016',
     'formattedAxisTime': 'Dec 4, 2016',
     'popularity': 33
   },
   {
-    'time': 1481414400,
+    'date': 1481414400,
     'formattedTime': 'Dec 11 - Dec 17 2016',
     'formattedAxisTime': 'Dec 11, 2016',
     'popularity': 34
   },
   {
-    'time': 1482019200,
+    'date': 1482019200,
     'formattedTime': 'Dec 18 - Dec 24 2016',
     'formattedAxisTime': 'Dec 18, 2016',
     'popularity': 33
   },
   {
-    'time': 1482624000,
+    'date': 1482624000,
     'formattedTime': 'Dec 25 - Dec 31 2016',
     'formattedAxisTime': 'Dec 25, 2016',
     'popularity': 31
   },
   {
-    'time': 1483228800,
+    'date': 1483228800,
     'formattedTime': 'Jan 1 - Jan 7 2017',
     'formattedAxisTime': 'Jan 1, 2017',
     'popularity': 31
   },
   {
-    'time': 1483833600,
+    'date': 1483833600,
     'formattedTime': 'Jan 8 - Jan 14 2017',
     'formattedAxisTime': 'Jan 8, 2017',
     'popularity': 29
   },
   {
-    'time': 1484438400,
+    'date': 1484438400,
     'formattedTime': 'Jan 15 - Jan 21 2017',
     'formattedAxisTime': 'Jan 15, 2017',
     'popularity': 28
   },
   {
-    'time': 1485043200,
+    'date': 1485043200,
     'formattedTime': 'Jan 22 - Jan 28 2017',
     'formattedAxisTime': 'Jan 22, 2017',
     'popularity': 28
   },
   {
-    'time': 1485648000,
+    'date': 1485648000,
     'formattedTime': 'Jan 29 - Feb 4 2017',
     'formattedAxisTime': 'Jan 29, 2017',
     'popularity': 28
   },
   {
-    'time': 1486252800,
+    'date': 1486252800,
     'formattedTime': 'Feb 5 - Feb 11 2017',
     'formattedAxisTime': 'Feb 5, 2017',
     'popularity': 29
   },
   {
-    'time': 1486857600,
+    'date': 1486857600,
     'formattedTime': 'Feb 12 - Feb 18 2017',
     'formattedAxisTime': 'Feb 12, 2017',
     'popularity': 30
   },
   {
-    'time': 1487462400,
+    'date': 1487462400,
     'formattedTime': 'Feb 19 - Feb 25 2017',
     'formattedAxisTime': 'Feb 19, 2017',
     'popularity': 32
   },
   {
-    'time': 1488067200,
+    'date': 1488067200,
     'formattedTime': 'Feb 26 - Mar 4 2017',
     'formattedAxisTime': 'Feb 26, 2017',
     'popularity': 33
   },
   {
-    'time': 1488672000,
+    'date': 1488672000,
     'formattedTime': 'Mar 5 - Mar 11 2017',
     'formattedAxisTime': 'Mar 5, 2017',
     'popularity': 31
   },
   {
-    'time': 1489276800,
+    'date': 1489276800,
     'formattedTime': 'Mar 12 - Mar 18 2017',
     'formattedAxisTime': 'Mar 12, 2017',
     'popularity': 30
   },
   {
-    'time': 1489881600,
+    'date': 1489881600,
     'formattedTime': 'Mar 19 - Mar 25 2017',
     'formattedAxisTime': 'Mar 19, 2017',
     'popularity': 31
   },
   {
-    'time': 1490486400,
+    'date': 1490486400,
     'formattedTime': 'Mar 26 - Apr 1 2017',
     'formattedAxisTime': 'Mar 26, 2017',
     'popularity': 32
   },
   {
-    'time': 1491091200,
+    'date': 1491091200,
     'formattedTime': 'Apr 2 - Apr 8 2017',
     'formattedAxisTime': 'Apr 2, 2017',
     'popularity': 30
   },
   {
-    'time': 1491696000,
+    'date': 1491696000,
     'formattedTime': 'Apr 9 - Apr 15 2017',
     'formattedAxisTime': 'Apr 9, 2017',
     'popularity': 30
   },
   {
-    'time': 1492300800,
+    'date': 1492300800,
     'formattedTime': 'Apr 16 - Apr 22 2017',
     'formattedAxisTime': 'Apr 16, 2017',
     'popularity': 30
   },
   {
-    'time': 1492905600,
+    'date': 1492905600,
     'formattedTime': 'Apr 23 - Apr 29 2017',
     'formattedAxisTime': 'Apr 23, 2017',
     'popularity': 31

--- a/integration-tests/fixtures/trend-sanitized.js
+++ b/integration-tests/fixtures/trend-sanitized.js
@@ -1,390 +1,390 @@
 module.exports = [
   {
-    'time': 1454198400,
+    'date': 1454198400,
     'formattedTime': 'Jan 31 - Feb 6 2016',
     'formattedAxisTime': 'Jan 31, 2016',
     'popularity': 33
   },
   {
-    'time': 1454803200,
+    'date': 1454803200,
     'formattedTime': 'Feb 7 - Feb 13 2016',
     'formattedAxisTime': 'Feb 7, 2016',
     'popularity': 38
   },
   {
-    'time': 1455408000,
+    'date': 1455408000,
     'formattedTime': 'Feb 14 - Feb 20 2016',
     'formattedAxisTime': 'Feb 14, 2016',
     'popularity': 34
   },
   {
-    'time': 1456012800,
+    'date': 1456012800,
     'formattedTime': 'Feb 21 - Feb 27 2016',
     'formattedAxisTime': 'Feb 21, 2016',
     'popularity': 33
   },
   {
-    'time': 1456617600,
+    'date': 1456617600,
     'formattedTime': 'Feb 28 - Mar 5 2016',
     'formattedAxisTime': 'Feb 28, 2016',
     'popularity': 33
   },
   {
-    'time': 1457222400,
+    'date': 1457222400,
     'formattedTime': 'Mar 6 - Mar 12 2016',
     'formattedAxisTime': 'Mar 6, 2016',
     'popularity': 33
   },
   {
-    'time': 1457827200,
+    'date': 1457827200,
     'formattedTime': 'Mar 13 - Mar 19 2016',
     'formattedAxisTime': 'Mar 13, 2016',
     'popularity': 35
   },
   {
-    'time': 1458432000,
+    'date': 1458432000,
     'formattedTime': 'Mar 20 - Mar 26 2016',
     'formattedAxisTime': 'Mar 20, 2016',
     'popularity': 35
   },
   {
-    'time': 1459036800,
+    'date': 1459036800,
     'formattedTime': 'Mar 27 - Apr 2 2016',
     'formattedAxisTime': 'Mar 27, 2016',
     'popularity': 36
   },
   {
-    'time': 1459641600,
+    'date': 1459641600,
     'formattedTime': 'Apr 3 - Apr 9 2016',
     'formattedAxisTime': 'Apr 3, 2016',
     'popularity': 34
   },
   {
-    'time': 1460246400,
+    'date': 1460246400,
     'formattedTime': 'Apr 10 - Apr 16 2016',
     'formattedAxisTime': 'Apr 10, 2016',
     'popularity': 38
   },
   {
-    'time': 1460851200,
+    'date': 1460851200,
     'formattedTime': 'Apr 17 - Apr 23 2016',
     'formattedAxisTime': 'Apr 17, 2016',
     'popularity': 38
   },
   {
-    'time': 1461456000,
+    'date': 1461456000,
     'formattedTime': 'Apr 24 - Apr 30 2016',
     'formattedAxisTime': 'Apr 24, 2016',
     'popularity': 38
   },
   {
-    'time': 1462060800,
+    'date': 1462060800,
     'formattedTime': 'May 1 - May 7 2016',
     'formattedAxisTime': 'May 1, 2016',
     'popularity': 44
   },
   {
-    'time': 1462665600,
+    'date': 1462665600,
     'formattedTime': 'May 8 - May 14 2016',
     'formattedAxisTime': 'May 8, 2016',
     'popularity': 52
   },
   {
-    'time': 1463270400,
+    'date': 1463270400,
     'formattedTime': 'May 15 - May 21 2016',
     'formattedAxisTime': 'May 15, 2016',
     'popularity': 48
   },
   {
-    'time': 1463875200,
+    'date': 1463875200,
     'formattedTime': 'May 22 - May 28 2016',
     'formattedAxisTime': 'May 22, 2016',
     'popularity': 62
   },
   {
-    'time': 1464480000,
+    'date': 1464480000,
     'formattedTime': 'May 29 - Jun 4 2016',
     'formattedAxisTime': 'May 29, 2016',
     'popularity': 100
   },
   {
-    'time': 1465084800,
+    'date': 1465084800,
     'formattedTime': 'Jun 5 - Jun 11 2016',
     'formattedAxisTime': 'Jun 5, 2016',
     'popularity': 96
   },
   {
-    'time': 1465689600,
+    'date': 1465689600,
     'formattedTime': 'Jun 12 - Jun 18 2016',
     'formattedAxisTime': 'Jun 12, 2016',
     'popularity': 71
   },
   {
-    'time': 1466294400,
+    'date': 1466294400,
     'formattedTime': 'Jun 19 - Jun 25 2016',
     'formattedAxisTime': 'Jun 19, 2016',
     'popularity': 56
   },
   {
-    'time': 1466899200,
+    'date': 1466899200,
     'formattedTime': 'Jun 26 - Jul 2 2016',
     'formattedAxisTime': 'Jun 26, 2016',
     'popularity': 52
   },
   {
-    'time': 1467504000,
+    'date': 1467504000,
     'formattedTime': 'Jul 3 - Jul 9 2016',
     'formattedAxisTime': 'Jul 3, 2016',
     'popularity': 48
   },
   {
-    'time': 1468108800,
+    'date': 1468108800,
     'formattedTime': 'Jul 10 - Jul 16 2016',
     'formattedAxisTime': 'Jul 10, 2016',
     'popularity': 44
   },
   {
-    'time': 1468713600,
+    'date': 1468713600,
     'formattedTime': 'Jul 17 - Jul 23 2016',
     'formattedAxisTime': 'Jul 17, 2016',
     'popularity': 42
   },
   {
-    'time': 1469318400,
+    'date': 1469318400,
     'formattedTime': 'Jul 24 - Jul 30 2016',
     'formattedAxisTime': 'Jul 24, 2016',
     'popularity': 42
   },
   {
-    'time': 1469923200,
+    'date': 1469923200,
     'formattedTime': 'Jul 31 - Aug 6 2016',
     'formattedAxisTime': 'Jul 31, 2016',
     'popularity': 40
   },
   {
-    'time': 1470528000,
+    'date': 1470528000,
     'formattedTime': 'Aug 7 - Aug 13 2016',
     'formattedAxisTime': 'Aug 7, 2016',
     'popularity': 40
   },
   {
-    'time': 1471132800,
+    'date': 1471132800,
     'formattedTime': 'Aug 14 - Aug 20 2016',
     'formattedAxisTime': 'Aug 14, 2016',
     'popularity': 40
   },
   {
-    'time': 1471737600,
+    'date': 1471737600,
     'formattedTime': 'Aug 21 - Aug 27 2016',
     'formattedAxisTime': 'Aug 21, 2016',
     'popularity': 37
   },
   {
-    'time': 1472342400,
+    'date': 1472342400,
     'formattedTime': 'Aug 28 - Sep 3 2016',
     'formattedAxisTime': 'Aug 28, 2016',
     'popularity': 49
   },
   {
-    'time': 1472947200,
+    'date': 1472947200,
     'formattedTime': 'Sep 4 - Sep 10 2016',
     'formattedAxisTime': 'Sep 4, 2016',
     'popularity': 49
   },
   {
-    'time': 1473552000,
+    'date': 1473552000,
     'formattedTime': 'Sep 11 - Sep 17 2016',
     'formattedAxisTime': 'Sep 11, 2016',
     'popularity': 46
   },
   {
-    'time': 1474156800,
+    'date': 1474156800,
     'formattedTime': 'Sep 18 - Sep 24 2016',
     'formattedAxisTime': 'Sep 18, 2016',
     'popularity': 52
   },
   {
-    'time': 1474761600,
+    'date': 1474761600,
     'formattedTime': 'Sep 25 - Oct 1 2016',
     'formattedAxisTime': 'Sep 25, 2016',
     'popularity': 43
   },
   {
-    'time': 1475366400,
+    'date': 1475366400,
     'formattedTime': 'Oct 2 - Oct 8 2016',
     'formattedAxisTime': 'Oct 2, 2016',
     'popularity': 38
   },
   {
-    'time': 1475971200,
+    'date': 1475971200,
     'formattedTime': 'Oct 9 - Oct 15 2016',
     'formattedAxisTime': 'Oct 9, 2016',
     'popularity': 37
   },
   {
-    'time': 1476576000,
+    'date': 1476576000,
     'formattedTime': 'Oct 16 - Oct 22 2016',
     'formattedAxisTime': 'Oct 16, 2016',
     'popularity': 35
   },
   {
-    'time': 1477180800,
+    'date': 1477180800,
     'formattedTime': 'Oct 23 - Oct 29 2016',
     'formattedAxisTime': 'Oct 23, 2016',
     'popularity': 37
   },
   {
-    'time': 1477785600,
+    'date': 1477785600,
     'formattedTime': 'Oct 30 - Nov 5 2016',
     'formattedAxisTime': 'Oct 30, 2016',
     'popularity': 36
   },
   {
-    'time': 1478390400,
+    'date': 1478390400,
     'formattedTime': 'Nov 6 - Nov 12 2016',
     'formattedAxisTime': 'Nov 6, 2016',
     'popularity': 31
   },
   {
-    'time': 1478995200,
+    'date': 1478995200,
     'formattedTime': 'Nov 13 - Nov 19 2016',
     'formattedAxisTime': 'Nov 13, 2016',
     'popularity': 32
   },
   {
-    'time': 1479600000,
+    'date': 1479600000,
     'formattedTime': 'Nov 20 - Nov 26 2016',
     'formattedAxisTime': 'Nov 20, 2016',
     'popularity': 32
   },
   {
-    'time': 1480204800,
+    'date': 1480204800,
     'formattedTime': 'Nov 27 - Dec 3 2016',
     'formattedAxisTime': 'Nov 27, 2016',
     'popularity': 32
   },
   {
-    'time': 1480809600,
+    'date': 1480809600,
     'formattedTime': 'Dec 4 - Dec 10 2016',
     'formattedAxisTime': 'Dec 4, 2016',
     'popularity': 33
   },
   {
-    'time': 1481414400,
+    'date': 1481414400,
     'formattedTime': 'Dec 11 - Dec 17 2016',
     'formattedAxisTime': 'Dec 11, 2016',
     'popularity': 34
   },
   {
-    'time': 1482019200,
+    'date': 1482019200,
     'formattedTime': 'Dec 18 - Dec 24 2016',
     'formattedAxisTime': 'Dec 18, 2016',
     'popularity': 33
   },
   {
-    'time': 1482624000,
+    'date': 1482624000,
     'formattedTime': 'Dec 25 - Dec 31 2016',
     'formattedAxisTime': 'Dec 25, 2016',
     'popularity': 31
   },
   {
-    'time': 1483228800,
+    'date': 1483228800,
     'formattedTime': 'Jan 1 - Jan 7 2017',
     'formattedAxisTime': 'Jan 1, 2017',
     'popularity': 31
   },
   {
-    'time': 1483833600,
+    'date': 1483833600,
     'formattedTime': 'Jan 8 - Jan 14 2017',
     'formattedAxisTime': 'Jan 8, 2017',
     'popularity': 29
   },
   {
-    'time': 1484438400,
+    'date': 1484438400,
     'formattedTime': 'Jan 15 - Jan 21 2017',
     'formattedAxisTime': 'Jan 15, 2017',
     'popularity': 28
   },
   {
-    'time': 1485043200,
+    'date': 1485043200,
     'formattedTime': 'Jan 22 - Jan 28 2017',
     'formattedAxisTime': 'Jan 22, 2017',
     'popularity': 28
   },
   {
-    'time': 1485648000,
+    'date': 1485648000,
     'formattedTime': 'Jan 29 - Feb 4 2017',
     'formattedAxisTime': 'Jan 29, 2017',
     'popularity': 28
   },
   {
-    'time': 1486252800,
+    'date': 1486252800,
     'formattedTime': 'Feb 5 - Feb 11 2017',
     'formattedAxisTime': 'Feb 5, 2017',
     'popularity': 29
   },
   {
-    'time': 1486857600,
+    'date': 1486857600,
     'formattedTime': 'Feb 12 - Feb 18 2017',
     'formattedAxisTime': 'Feb 12, 2017',
     'popularity': 30
   },
   {
-    'time': 1487462400,
+    'date': 1487462400,
     'formattedTime': 'Feb 19 - Feb 25 2017',
     'formattedAxisTime': 'Feb 19, 2017',
     'popularity': 32
   },
   {
-    'time': 1488067200,
+    'date': 1488067200,
     'formattedTime': 'Feb 26 - Mar 4 2017',
     'formattedAxisTime': 'Feb 26, 2017',
     'popularity': 33
   },
   {
-    'time': 1488672000,
+    'date': 1488672000,
     'formattedTime': 'Mar 5 - Mar 11 2017',
     'formattedAxisTime': 'Mar 5, 2017',
     'popularity': 31
   },
   {
-    'time': 1489276800,
+    'date': 1489276800,
     'formattedTime': 'Mar 12 - Mar 18 2017',
     'formattedAxisTime': 'Mar 12, 2017',
     'popularity': 30
   },
   {
-    'time': 1489881600,
+    'date': 1489881600,
     'formattedTime': 'Mar 19 - Mar 25 2017',
     'formattedAxisTime': 'Mar 19, 2017',
     'popularity': 31
   },
   {
-    'time': 1490486400,
+    'date': 1490486400,
     'formattedTime': 'Mar 26 - Apr 1 2017',
     'formattedAxisTime': 'Mar 26, 2017',
     'popularity': 32
   },
   {
-    'time': 1491091200,
+    'date': 1491091200,
     'formattedTime': 'Apr 2 - Apr 8 2017',
     'formattedAxisTime': 'Apr 2, 2017',
     'popularity': 30
   },
   {
-    'time': 1491696000,
+    'date': 1491696000,
     'formattedTime': 'Apr 9 - Apr 15 2017',
     'formattedAxisTime': 'Apr 9, 2017',
     'popularity': 30
   },
   {
-    'time': 1492300800,
+    'date': 1492300800,
     'formattedTime': 'Apr 16 - Apr 22 2017',
     'formattedAxisTime': 'Apr 16, 2017',
     'popularity': 30
   },
   {
-    'time': 1492905600,
+    'date': 1492905600,
     'formattedTime': 'Apr 23 - Apr 29 2017',
     'formattedAxisTime': 'Apr 23, 2017',
     'popularity': 31

--- a/integration-tests/fixtures/trend-sanitized.js
+++ b/integration-tests/fixtures/trend-sanitized.js
@@ -1,392 +1,392 @@
-module.exports = timelineData = [
+module.exports = [
   {
     'time': 1454198400,
     'formattedTime': 'Jan 31 - Feb 6 2016',
     'formattedAxisTime': 'Jan 31, 2016',
-    'value': 33
+    'popularity': 33
   },
   {
     'time': 1454803200,
     'formattedTime': 'Feb 7 - Feb 13 2016',
     'formattedAxisTime': 'Feb 7, 2016',
-    'value': 38
+    'popularity': 38
   },
   {
     'time': 1455408000,
     'formattedTime': 'Feb 14 - Feb 20 2016',
     'formattedAxisTime': 'Feb 14, 2016',
-    'value': 34
+    'popularity': 34
   },
   {
     'time': 1456012800,
     'formattedTime': 'Feb 21 - Feb 27 2016',
     'formattedAxisTime': 'Feb 21, 2016',
-    'value': 33
+    'popularity': 33
   },
   {
     'time': 1456617600,
     'formattedTime': 'Feb 28 - Mar 5 2016',
     'formattedAxisTime': 'Feb 28, 2016',
-    'value': 33
+    'popularity': 33
   },
   {
     'time': 1457222400,
     'formattedTime': 'Mar 6 - Mar 12 2016',
     'formattedAxisTime': 'Mar 6, 2016',
-    'value': 33
+    'popularity': 33
   },
   {
     'time': 1457827200,
     'formattedTime': 'Mar 13 - Mar 19 2016',
     'formattedAxisTime': 'Mar 13, 2016',
-    'value': 35
+    'popularity': 35
   },
   {
     'time': 1458432000,
     'formattedTime': 'Mar 20 - Mar 26 2016',
     'formattedAxisTime': 'Mar 20, 2016',
-    'value': 35
+    'popularity': 35
   },
   {
     'time': 1459036800,
     'formattedTime': 'Mar 27 - Apr 2 2016',
     'formattedAxisTime': 'Mar 27, 2016',
-    'value': 36
+    'popularity': 36
   },
   {
     'time': 1459641600,
     'formattedTime': 'Apr 3 - Apr 9 2016',
     'formattedAxisTime': 'Apr 3, 2016',
-    'value': 34
+    'popularity': 34
   },
   {
     'time': 1460246400,
     'formattedTime': 'Apr 10 - Apr 16 2016',
     'formattedAxisTime': 'Apr 10, 2016',
-    'value': 38
+    'popularity': 38
   },
   {
     'time': 1460851200,
     'formattedTime': 'Apr 17 - Apr 23 2016',
     'formattedAxisTime': 'Apr 17, 2016',
-    'value': 38
+    'popularity': 38
   },
   {
     'time': 1461456000,
     'formattedTime': 'Apr 24 - Apr 30 2016',
     'formattedAxisTime': 'Apr 24, 2016',
-    'value': 38
+    'popularity': 38
   },
   {
     'time': 1462060800,
     'formattedTime': 'May 1 - May 7 2016',
     'formattedAxisTime': 'May 1, 2016',
-    'value': 44
+    'popularity': 44
   },
   {
     'time': 1462665600,
     'formattedTime': 'May 8 - May 14 2016',
     'formattedAxisTime': 'May 8, 2016',
-    'value': 52
+    'popularity': 52
   },
   {
     'time': 1463270400,
     'formattedTime': 'May 15 - May 21 2016',
     'formattedAxisTime': 'May 15, 2016',
-    'value': 48
+    'popularity': 48
   },
   {
     'time': 1463875200,
     'formattedTime': 'May 22 - May 28 2016',
     'formattedAxisTime': 'May 22, 2016',
-    'value': 62
+    'popularity': 62
   },
   {
     'time': 1464480000,
     'formattedTime': 'May 29 - Jun 4 2016',
     'formattedAxisTime': 'May 29, 2016',
-    'value': 100
+    'popularity': 100
   },
   {
     'time': 1465084800,
     'formattedTime': 'Jun 5 - Jun 11 2016',
     'formattedAxisTime': 'Jun 5, 2016',
-    'value': 96
+    'popularity': 96
   },
   {
     'time': 1465689600,
     'formattedTime': 'Jun 12 - Jun 18 2016',
     'formattedAxisTime': 'Jun 12, 2016',
-    'value': 71
+    'popularity': 71
   },
   {
     'time': 1466294400,
     'formattedTime': 'Jun 19 - Jun 25 2016',
     'formattedAxisTime': 'Jun 19, 2016',
-    'value': 56
+    'popularity': 56
   },
   {
     'time': 1466899200,
     'formattedTime': 'Jun 26 - Jul 2 2016',
     'formattedAxisTime': 'Jun 26, 2016',
-    'value': 52
+    'popularity': 52
   },
   {
     'time': 1467504000,
     'formattedTime': 'Jul 3 - Jul 9 2016',
     'formattedAxisTime': 'Jul 3, 2016',
-    'value': 48
+    'popularity': 48
   },
   {
     'time': 1468108800,
     'formattedTime': 'Jul 10 - Jul 16 2016',
     'formattedAxisTime': 'Jul 10, 2016',
-    'value': 44
+    'popularity': 44
   },
   {
     'time': 1468713600,
     'formattedTime': 'Jul 17 - Jul 23 2016',
     'formattedAxisTime': 'Jul 17, 2016',
-    'value': 42
+    'popularity': 42
   },
   {
     'time': 1469318400,
     'formattedTime': 'Jul 24 - Jul 30 2016',
     'formattedAxisTime': 'Jul 24, 2016',
-    'value': 42
+    'popularity': 42
   },
   {
     'time': 1469923200,
     'formattedTime': 'Jul 31 - Aug 6 2016',
     'formattedAxisTime': 'Jul 31, 2016',
-    'value': 40
+    'popularity': 40
   },
   {
     'time': 1470528000,
     'formattedTime': 'Aug 7 - Aug 13 2016',
     'formattedAxisTime': 'Aug 7, 2016',
-    'value': 40
+    'popularity': 40
   },
   {
     'time': 1471132800,
     'formattedTime': 'Aug 14 - Aug 20 2016',
     'formattedAxisTime': 'Aug 14, 2016',
-    'value': 40
+    'popularity': 40
   },
   {
     'time': 1471737600,
     'formattedTime': 'Aug 21 - Aug 27 2016',
     'formattedAxisTime': 'Aug 21, 2016',
-    'value': 37
+    'popularity': 37
   },
   {
     'time': 1472342400,
     'formattedTime': 'Aug 28 - Sep 3 2016',
     'formattedAxisTime': 'Aug 28, 2016',
-    'value': 49
+    'popularity': 49
   },
   {
     'time': 1472947200,
     'formattedTime': 'Sep 4 - Sep 10 2016',
     'formattedAxisTime': 'Sep 4, 2016',
-    'value': 49
+    'popularity': 49
   },
   {
     'time': 1473552000,
     'formattedTime': 'Sep 11 - Sep 17 2016',
     'formattedAxisTime': 'Sep 11, 2016',
-    'value': 46
+    'popularity': 46
   },
   {
     'time': 1474156800,
     'formattedTime': 'Sep 18 - Sep 24 2016',
     'formattedAxisTime': 'Sep 18, 2016',
-    'value': 52
+    'popularity': 52
   },
   {
     'time': 1474761600,
     'formattedTime': 'Sep 25 - Oct 1 2016',
     'formattedAxisTime': 'Sep 25, 2016',
-    'value': 43
+    'popularity': 43
   },
   {
     'time': 1475366400,
     'formattedTime': 'Oct 2 - Oct 8 2016',
     'formattedAxisTime': 'Oct 2, 2016',
-    'value': 38
+    'popularity': 38
   },
   {
     'time': 1475971200,
     'formattedTime': 'Oct 9 - Oct 15 2016',
     'formattedAxisTime': 'Oct 9, 2016',
-    'value': 37
+    'popularity': 37
   },
   {
     'time': 1476576000,
     'formattedTime': 'Oct 16 - Oct 22 2016',
     'formattedAxisTime': 'Oct 16, 2016',
-    'value': 35
+    'popularity': 35
   },
   {
     'time': 1477180800,
     'formattedTime': 'Oct 23 - Oct 29 2016',
     'formattedAxisTime': 'Oct 23, 2016',
-    'value': 37
+    'popularity': 37
   },
   {
     'time': 1477785600,
     'formattedTime': 'Oct 30 - Nov 5 2016',
     'formattedAxisTime': 'Oct 30, 2016',
-    'value': 36
+    'popularity': 36
   },
   {
     'time': 1478390400,
     'formattedTime': 'Nov 6 - Nov 12 2016',
     'formattedAxisTime': 'Nov 6, 2016',
-    'value': 31
+    'popularity': 31
   },
   {
     'time': 1478995200,
     'formattedTime': 'Nov 13 - Nov 19 2016',
     'formattedAxisTime': 'Nov 13, 2016',
-    'value': 32
+    'popularity': 32
   },
   {
     'time': 1479600000,
     'formattedTime': 'Nov 20 - Nov 26 2016',
     'formattedAxisTime': 'Nov 20, 2016',
-    'value': 32
+    'popularity': 32
   },
   {
     'time': 1480204800,
     'formattedTime': 'Nov 27 - Dec 3 2016',
     'formattedAxisTime': 'Nov 27, 2016',
-    'value': 32
+    'popularity': 32
   },
   {
     'time': 1480809600,
     'formattedTime': 'Dec 4 - Dec 10 2016',
     'formattedAxisTime': 'Dec 4, 2016',
-    'value': 33
+    'popularity': 33
   },
   {
     'time': 1481414400,
     'formattedTime': 'Dec 11 - Dec 17 2016',
     'formattedAxisTime': 'Dec 11, 2016',
-    'value': 34
+    'popularity': 34
   },
   {
     'time': 1482019200,
     'formattedTime': 'Dec 18 - Dec 24 2016',
     'formattedAxisTime': 'Dec 18, 2016',
-    'value': 33
+    'popularity': 33
   },
   {
     'time': 1482624000,
     'formattedTime': 'Dec 25 - Dec 31 2016',
     'formattedAxisTime': 'Dec 25, 2016',
-    'value': 31
+    'popularity': 31
   },
   {
     'time': 1483228800,
     'formattedTime': 'Jan 1 - Jan 7 2017',
     'formattedAxisTime': 'Jan 1, 2017',
-    'value': 31
+    'popularity': 31
   },
   {
     'time': 1483833600,
     'formattedTime': 'Jan 8 - Jan 14 2017',
     'formattedAxisTime': 'Jan 8, 2017',
-    'value': 29
+    'popularity': 29
   },
   {
     'time': 1484438400,
     'formattedTime': 'Jan 15 - Jan 21 2017',
     'formattedAxisTime': 'Jan 15, 2017',
-    'value': 28
+    'popularity': 28
   },
   {
     'time': 1485043200,
     'formattedTime': 'Jan 22 - Jan 28 2017',
     'formattedAxisTime': 'Jan 22, 2017',
-    'value': 28
+    'popularity': 28
   },
   {
     'time': 1485648000,
     'formattedTime': 'Jan 29 - Feb 4 2017',
     'formattedAxisTime': 'Jan 29, 2017',
-    'value': 28
+    'popularity': 28
   },
   {
     'time': 1486252800,
     'formattedTime': 'Feb 5 - Feb 11 2017',
     'formattedAxisTime': 'Feb 5, 2017',
-    'value': 29
+    'popularity': 29
   },
   {
     'time': 1486857600,
     'formattedTime': 'Feb 12 - Feb 18 2017',
     'formattedAxisTime': 'Feb 12, 2017',
-    'value': 30
+    'popularity': 30
   },
   {
     'time': 1487462400,
     'formattedTime': 'Feb 19 - Feb 25 2017',
     'formattedAxisTime': 'Feb 19, 2017',
-    'value': 32
+    'popularity': 32
   },
   {
     'time': 1488067200,
     'formattedTime': 'Feb 26 - Mar 4 2017',
     'formattedAxisTime': 'Feb 26, 2017',
-    'value': 33
+    'popularity': 33
   },
   {
     'time': 1488672000,
     'formattedTime': 'Mar 5 - Mar 11 2017',
     'formattedAxisTime': 'Mar 5, 2017',
-    'value': 31
+    'popularity': 31
   },
   {
     'time': 1489276800,
     'formattedTime': 'Mar 12 - Mar 18 2017',
     'formattedAxisTime': 'Mar 12, 2017',
-    'value': 30
+    'popularity': 30
   },
   {
     'time': 1489881600,
     'formattedTime': 'Mar 19 - Mar 25 2017',
     'formattedAxisTime': 'Mar 19, 2017',
-    'value': 31
+    'popularity': 31
   },
   {
     'time': 1490486400,
     'formattedTime': 'Mar 26 - Apr 1 2017',
     'formattedAxisTime': 'Mar 26, 2017',
-    'value': 32
+    'popularity': 32
   },
   {
     'time': 1491091200,
     'formattedTime': 'Apr 2 - Apr 8 2017',
     'formattedAxisTime': 'Apr 2, 2017',
-    'value': 30
+    'popularity': 30
   },
   {
     'time': 1491696000,
     'formattedTime': 'Apr 9 - Apr 15 2017',
     'formattedAxisTime': 'Apr 9, 2017',
-    'value': 30
+    'popularity': 30
   },
   {
     'time': 1492300800,
     'formattedTime': 'Apr 16 - Apr 22 2017',
     'formattedAxisTime': 'Apr 16, 2017',
-    'value': 30
+    'popularity': 30
   },
   {
     'time': 1492905600,
     'formattedTime': 'Apr 23 - Apr 29 2017',
     'formattedAxisTime': 'Apr 23, 2017',
-    'value': 31
+    'popularity': 31
   }
 ];

--- a/utilities/peakAlgo.js
+++ b/utilities/peakAlgo.js
@@ -2,9 +2,9 @@ const findPeaks = function(timeSeries) {
   let peaks = [[0, -1]];
 
   timeSeries.forEach((data) => {
-    if (data.value > peaks[0][1]) {
+    if (data.popularity > peaks[0][1]) {
       peaks.length = 0;
-      peaks.push([data.time, data.value]);
+      peaks.push([data.time, data.popularity]);
     }
   });
 

--- a/utilities/peakAlgo.js
+++ b/utilities/peakAlgo.js
@@ -4,7 +4,7 @@ const findPeaks = function(timeSeries) {
   timeSeries.forEach((data) => {
     if (data.popularity > peaks[0][1]) {
       peaks.length = 0;
-      peaks.push([data.time, data.popularity]);
+      peaks.push([data.date, data.popularity]);
     }
   });
 

--- a/utilities/sanitizeTrend.js
+++ b/utilities/sanitizeTrend.js
@@ -12,7 +12,7 @@ module.exports = (rawTimeline) => {
       time: parseInt(point.time),
       formattedTime: point.formattedTime,
       formattedAxisTime: point.formattedAxisTime,
-      value: point.value[0]
+      popularity: point.value[0]
     };
   });
 };

--- a/utilities/sanitizeTrend.js
+++ b/utilities/sanitizeTrend.js
@@ -9,7 +9,7 @@ module.exports = (rawTimeline) => {
 
   return parsedTimeline.default.timelineData.map((point) => {
     return {
-      time: parseInt(point.time),
+      date: parseInt(point.time),
       formattedTime: point.formattedTime,
       formattedAxisTime: point.formattedAxisTime,
       popularity: point.value[0]


### PR DESCRIPTION
Changes

1. Change all references of `time` to `date` to match news API and frontend
2. Change all references of `value` to `popularity` to match news API and frontend
3. Add new `stitched-timeline` example data file with these updates that combines trend query and news stories query at **one** peak