### PR TITLE
Feat/add timeline endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,8 +24,8 @@ app.get('/api', (req, res) => {
   });
 });
 
-app.post('/api/timeline', (req, res) => {
-  makeTimeline(req.body.keyword, (err, data) => {
+app.get('/api/timeline', (req, res) => {
+  makeTimeline(req.query.q, (err, data) => {
     if (err) {
       res.status(500).send('Error:', err);
     } else {

--- a/server.js
+++ b/server.js
@@ -1,4 +1,4 @@
-const trendQuery = require('./utilities/trendQuery');
+const makeTimeline = require('./utilities/makeTimeline');
 
 const express = require('express');
 const bodyParser = require('body-parser');
@@ -24,8 +24,8 @@ app.get('/api', (req, res) => {
   });
 });
 
-app.post('/', (req, res) => {
-  trendQuery(req.body.keyword, (err, data) => {
+app.post('/api/timeline', (req, res) => {
+  makeTimeline(req.body.keyword, (err, data) => {
     if (err) {
       res.status(500).send('Error:', err);
     } else {


### PR DESCRIPTION
## Notes

1. Use `makeTimeline` to actually return full timeline with trend + stories at the peak
2. Change endpoint url from `/` to `/api/timeline`
3. Change HTTP request from `POST` to `GET` so we can use URL to query
4. Use URL format to query `/api/timeline?q=<keyword(s)>` eg, `/api/timeline?q=hillary%20clinton`