### PR TITLE
(bug) Fix invalid http response

### DIFF
--- a/server.js
+++ b/server.js
@@ -27,7 +27,7 @@ app.get('/api', (req, res) => {
 app.get('/api/timeline', (req, res) => {
   makeTimeline(req.query.q, (err, data) => {
     if (err) {
-      res.status(500).send('Error:', err);
+      res.status(500).send(err);
     } else {
       res.send(data);
     }

--- a/server.js
+++ b/server.js
@@ -29,7 +29,7 @@ app.get('/api/timeline', (req, res) => {
     if (err) {
       res.status(500).send(err);
     } else {
-      res.send(data);
+      res.status(200).send(data);
     }
   });
 });

--- a/utilities/aylienApi.js
+++ b/utilities/aylienApi.js
@@ -24,14 +24,14 @@ const getStories = (queryString, peaks, callback) => {
 
   let appId = apiInstance.apiClient.authentications['app_id'];
   try {
-    appId.apiKey = AYLIEN_ID;
+    appId.apiKey = process.env.AYLIEN_ID;
   } catch (e) {
     appId.apiKey = apiInfo.id;
   }
 
   let appKey = apiInstance.apiClient.authentications['app_key'];
   try {
-    appKey.apiKey = AYLIEN_KEY;
+    appKey.apiKey = process.env.AYLIEN_KEY;
   } catch (e) {
     appKey.apiKey = apiInfo.key;
   }


### PR DESCRIPTION
based on the heroku logs, i think this crashed the heroku app when there was an error. or maybe the deprecated `res.send(result)` without explicit response code

also fixes reference to config vars for aylien news api