### PR TITLE
Feat/search form

### DIFF
--- a/client/app/components/Header.jsx
+++ b/client/app/components/Header.jsx
@@ -4,7 +4,7 @@ export default class Header extends React.Component {
   render () {
     return (
       <div className="row">
-        <div className="col-12">
+        <div className="col-12 mt-4 mb-4">
           <h1>TrendGame</h1>
         </div>
       </div>

--- a/client/app/components/History.jsx
+++ b/client/app/components/History.jsx
@@ -4,8 +4,8 @@ import HistoryItem from './HistoryItem';
 const History = ({ history }) => {
   return (
     <div className="col-4">
-      <h6>Search History</h6>
-      <ul>
+      <h6>Recent searches</h6>
+      <ul className="list-group">
         {history.map(term => {
           return <HistoryItem key={term} term={term}/>;
         })}

--- a/client/app/components/HistoryItem.jsx
+++ b/client/app/components/HistoryItem.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 
-const HistoryItem = ({ term }) => {
-  return (
-    <li>{term}</li>
-  );
-};
+const HistoryItem = ({ term }) => (
+  <li className="list-group-item">{term}</li>
+);
 
 export default HistoryItem;

--- a/client/app/components/Input.jsx
+++ b/client/app/components/Input.jsx
@@ -29,7 +29,7 @@ export default class Input extends React.Component {
     return (
       <div className="row">
         <div className="col-12">
-          <div className="form-group">
+          <div className="input-group">
             <input
               className="form-control"
               type="text"
@@ -39,12 +39,15 @@ export default class Input extends React.Component {
               autoFocus
             >
             </input>
-            <input
-              className="form-control"
-              type="submit"
-              onClick={this.submitTrend}
-            >
-            </input>
+            <span className="input-group-btn">
+              <button
+                className="btn btn-primary"
+                type="button"
+                onClick={this.submitTrend}
+              >
+                Search
+              </button>
+            </span>
           </div>
         </div>
       </div>

--- a/client/app/components/Input.jsx
+++ b/client/app/components/Input.jsx
@@ -29,9 +29,23 @@ export default class Input extends React.Component {
     return (
       <div className="row">
         <div className="col-12">
-          <h6>Search for a trend</h6>
-          <input placeholder="Enter a topic" onKeyPress={this.onEnter} onChange={this.handeInput}></input>
-          <input type="submit" onClick={this.submitTrend}></input>
+          <div className="form-group">
+            <input
+              className="form-control"
+              type="text"
+              placeholder="Enter a topic"
+              onKeyPress={this.onEnter}
+              onChange={this.handeInput}
+              autoFocus
+            >
+            </input>
+            <input
+              className="form-control"
+              type="submit"
+              onClick={this.submitTrend}
+            >
+            </input>
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
# Changes
1. Use bootstrap inline form styling for search form
2. Autofocus in the input
3. Remove heading label above input (good?)

# Landing page

## Before

![screen shot 2017-05-11 at 7 36 48 pm](https://cloud.githubusercontent.com/assets/892749/25980098/5140f816-3681-11e7-913b-615563e555e5.png)

## After

![screen shot 2017-05-11 at 7 36 53 pm](https://cloud.githubusercontent.com/assets/892749/25980142/8be860a8-3681-11e7-9422-293db0ae4372.png)

# Search results

## Before

![screen shot 2017-05-11 at 7 36 36 pm](https://cloud.githubusercontent.com/assets/892749/25980107/5fbc6380-3681-11e7-82f0-44c370a75793.png)

## After

![screen shot 2017-05-11 at 7 36 42 pm](https://cloud.githubusercontent.com/assets/892749/25980126/7dfe2338-3681-11e7-9271-1300c8a21547.png)

