### PR TITLE
Feat/search string cleanup

### DIFF
--- a/client/app/index.jsx
+++ b/client/app/index.jsx
@@ -26,10 +26,6 @@ class App extends React.Component {
   }
 
   collectData(trend) {
-    if (trend[0] !== '"' && trend[trend.length - 1] !== '"') {
-      trend = '"' + trend + '"';
-    }
-
     this.setState({
       loader: <Loader color="#26A65B" size="16px" margin="4px"/>,
       storyPoint: {}

--- a/client/app/index.jsx
+++ b/client/app/index.jsx
@@ -34,9 +34,9 @@ class App extends React.Component {
       params: { q: trend }
     })
     .then(response => {
-      let timeline = response.data;
+      let timeline = response.data.timeline;
       this.setState({
-        trend: trend,
+        trend: response.data.trend,
         start: timeline[0].date,
         end: timeline[timeline.length - 1].date,
         storyPoint: this.findStoryPoint(timeline),

--- a/client/app/index.jsx
+++ b/client/app/index.jsx
@@ -80,6 +80,8 @@ class App extends React.Component {
       search: trend
     }).then(response => {
       this.getSearchHistory();
+    }).catch(err => {
+      console.log(err);
     });
   }
 

--- a/client/app/index.jsx
+++ b/client/app/index.jsx
@@ -26,6 +26,10 @@ class App extends React.Component {
   }
 
   collectData(trend) {
+    if (trend[0] !== '"' && trend[trend.length - 1] !== '"') {
+      trend = '"' + trend + '"';
+    }
+
     this.setState({
       loader: <Loader color="#26A65B" size="16px" margin="4px"/>,
       storyPoint: {}

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 const makeTimeline = require('./utilities/makeTimeline');
 const queries = require('./db/queries');
+const cleanData = require('./utilities/cleanSearch');
 
 const express = require('express');
 const bodyParser = require('body-parser');
@@ -26,7 +27,10 @@ app.get('/api', (req, res) => {
 });
 
 app.get('/api/timeline', (req, res) => {
-  makeTimeline(req.query.q, (err, data) => {
+  let trend = req.query.q;
+  trend = cleanData.prepForAylien(trend);
+
+  makeTimeline(trend, (err, data) => {
     if (err) {
       res.status(500).send(err);
     } else {
@@ -58,5 +62,5 @@ app.get('/api/history', (req, res) => {
 app.use((req, res) => {
   res.status(404);
   res.sendFile(__dirname + '/404.html');
-})
+});
 module.exports = app;

--- a/server.js
+++ b/server.js
@@ -40,13 +40,19 @@ app.get('/api/timeline', (req, res) => {
 });
 
 app.post('/api/history', (req, res) => {
-  queries.insertSearch(req.body.search, (err, resp) => {
-    if (err) {
-      res.status(500).send(err);
-    } else {
-      res.status(200).send(resp);
-    }
-  });
+  let trend = req.body.search;
+
+  if (cleanData.checkIsReadyForDb(trend)) {
+    queries.insertSearch(req.body.search, (err, resp) => {
+      if (err) {
+        res.status(500).send(err);
+      } else {
+        res.status(200).send(resp);
+      }
+    });
+  } else {
+    res.status(400).send();
+  }
 });
 
 app.get('/api/history', (req, res) => {

--- a/server.js
+++ b/server.js
@@ -43,7 +43,9 @@ app.post('/api/history', (req, res) => {
   let trend = req.body.search;
 
   if (cleanData.checkIsReadyForDb(trend)) {
-    queries.insertSearch(req.body.search, (err, resp) => {
+    trend = cleanData.prepForDb(trend);
+
+    queries.insertSearch(trend, (err, resp) => {
       if (err) {
         res.status(500).send(err);
       } else {

--- a/utilities/cleanSearch.js
+++ b/utilities/cleanSearch.js
@@ -11,7 +11,7 @@ const checkForAllSpaces = (trend) => {
 const prepForAylien = (trend) => {
   trend = trend.toLowerCase();
 
-  if (trend.length === 0 || this.checkForAllSpaces(trend)) {
+  if (trend.length === 0 || checkForAllSpaces(trend)) {
     trend = '"the void"';
   }
 
@@ -23,7 +23,7 @@ const prepForAylien = (trend) => {
 };
 
 const checkIsReadyForDb = (trend) => {
-  if (trend.length === 0 || this.checkForAllSpaces(trend)) {
+  if (trend.length === 0 || checkForAllSpaces(trend)) {
     return false;
   }
 

--- a/utilities/cleanSearch.js
+++ b/utilities/cleanSearch.js
@@ -1,0 +1,45 @@
+const checkForAllSpaces = (trend) => {
+  for (let i = 0; i < trend.length; i++) {
+    if (trend[i] !== ' ') {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const prepForAylien = (trend) => {
+  trend = trend.toLowerCase();
+
+  if (trend.length === 0 || this.checkForAllSpaces(trend)) {
+    trend = '"the void"';
+  }
+
+  if (trend[0] !== '"' && trend[trend.length - 1] !== '"') {
+    trend = '"' + trend + '"';
+  }
+
+  return trend;
+};
+
+const checkIsReadyForDb = (trend) => {
+  if (trend.length === 0 || this.checkForAllSpaces(trend)) {
+    return false;
+  }
+
+  return true;
+};
+
+const prepForDb = (trend) => {
+  trend = trend.toLowerCase();
+
+  if (trend[0] === '"' && trend[trend.length - 1] === '"') {
+    trend = trend.slice(1, -1);
+  }
+
+  return trend;
+};
+
+module.exports.prepForAylien = prepForAylien;
+module.exports.checkIsReadyForDb = checkIsReadyForDb;
+module.exports.prepForDb = prepForDb;

--- a/utilities/makeTimeline.js
+++ b/utilities/makeTimeline.js
@@ -16,7 +16,12 @@ const makeTimeline = (searchString, callback) => {
         } else {
           const timeline = makeFinalData(timeSeries, peakStories);
 
-          callback(null, timeline);
+          const response = {
+            timeline: timeline,
+            trend: searchString.slice(1, -1)
+          };
+
+          callback(null, response);
         }
       });
     }


### PR DESCRIPTION
tl;dr: Cleans data in slightly different ways prior to aylien search and db insert.

index.jsx: Became necessary to slightly modify the server response to a search to include the search term so the graph displayed the properly cleaned search term.  Changed this file to adjust for the new data structure.

server.js: Runs data through cleaning helpers prior to passing them off to the aylien/db insert functions.

cleanSearch: Helper file with 3 separate cleaning functions and 1 additional internal helper.

makeTimeline.js: Modified to pass along necessary data for proper front-end display.

<img width="753" alt="screen shot 2017-05-11 at 7 43 04 pm" src="https://cloud.githubusercontent.com/assets/16528499/25980236/1d7417ba-3682-11e7-9632-1c40548acffb.png">
