### PR TITLE
Feat/relocate history and center all the things

### DIFF
--- a/client/app/components/Body.jsx
+++ b/client/app/components/Body.jsx
@@ -8,6 +8,7 @@ export default class Body extends React.Component {
     return (
       <div className="col-8">
         <Input collectData={this.props.collectData}/>
+
         <TrendChart chartData={this.props.chartData} storyPoint={this.props.storyPoint}/>
         <ArticleList storyPoint={this.props.storyPoint}/>
       </div>

--- a/client/app/components/Body.jsx
+++ b/client/app/components/Body.jsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import TrendChart from './Chart';
 import Input from './Input';
+import History from './History';
 import ArticleList from './ArticleList';
 
-export default class Body extends React.Component {
-  render () {
-    return (
-      <div className="col-8">
-        <Input collectData={this.props.collectData}/>
+const Body = (props) => {
+  return (
+    <div className="col-8 offset-2">
+      <Input collectData={props.collectData}/>
+      <History history={props.history}/>
+      <TrendChart chartData={props.chartData} storyPoint={props.storyPoint}/>
+      <ArticleList storyPoint={props.storyPoint}/>
+    </div>
+  );
+};
 
-        <TrendChart chartData={this.props.chartData} storyPoint={this.props.storyPoint}/>
-        <ArticleList storyPoint={this.props.storyPoint}/>
-      </div>
-    );
-  }
-}
+export default Body;

--- a/client/app/components/Chart.jsx
+++ b/client/app/components/Chart.jsx
@@ -8,26 +8,29 @@ const TrendChart = ({ chartData, storyPoint }) => {
     displayChart = loader;
   } else {
     displayChart = (
-      <div className="row mb-5">
-        <div className="col-12">
-          <Chart
-            chartType="LineChart"
-            data={data}
-            options={{
-              title: `${trend} popularity peaked at ${storyPoint.formattedAxisTime}`,
-              hAxis: { title: 'Date', minValue: start, maxValue: end },
-              vAxis: { title: 'Popularity', minValue: 0, maxValue: 100 },
-              legend: 'none'
-            }}
-            graph_id="LineChart"
-            width="100%"
-            height="400px"
-            legend_toggle
-          />
-        </div>
-    </div>);
+      <Chart
+        chartType="LineChart"
+        data={data}
+        options={{
+          title: `${trend} popularity peaked at ${storyPoint.formattedAxisTime}`,
+          hAxis: { title: 'Date', minValue: start, maxValue: end },
+          vAxis: { title: 'Popularity', minValue: 0, maxValue: 100 },
+          legend: 'none'
+        }}
+        graph_id="LineChart"
+        width="100%"
+        height="400px"
+        legend_toggle
+      />
+    );
   }
-  return (displayChart);
+  return (
+    <div className="row mb-5">
+      <div className="col-12 text-center">
+        {displayChart}
+      </div>
+    </div>
+  );
 };
 
 export default TrendChart;

--- a/client/app/components/Footer.jsx
+++ b/client/app/components/Footer.jsx
@@ -4,7 +4,7 @@ export default class Footer extends React.Component {
   render () {
     return (
       <footer className="footer">
-        <div className="container">
+        <div className="container text-center">
           <a href="https://github.com/TrendGame/TrendGame" className="text-muted">About this project</a>
         </div>
       </footer>

--- a/client/app/components/Header.jsx
+++ b/client/app/components/Header.jsx
@@ -5,7 +5,7 @@ export default class Header extends React.Component {
     return (
       <div className="row">
         <div className="col-12 mt-4 mb-4">
-          <h1>TrendGame</h1>
+          <h1 className="text-center">TrendGame</h1>
         </div>
       </div>
     );

--- a/client/app/components/History.jsx
+++ b/client/app/components/History.jsx
@@ -3,13 +3,15 @@ import HistoryItem from './HistoryItem';
 
 const History = ({ history }) => {
   return (
-    <div className="col-4">
-      <h6>Recent searches</h6>
-      <ul className="list-inline">
-        {history.map(term => {
-          return <HistoryItem key={term} term={term}/>;
-        })}
-      </ul>
+    <div className="row">
+      <div className="col-12 text-center">
+        <small>Recent searches</small>
+        <ul className="list-inline text-center text-muted">
+          {history.map((term, index) => {
+            return <HistoryItem key={term} term={term} index={index}/>;
+          })}
+        </ul>
+      </div>
     </div>
   );
 };

--- a/client/app/components/History.jsx
+++ b/client/app/components/History.jsx
@@ -5,7 +5,7 @@ const History = ({ history }) => {
   return (
     <div className="col-4">
       <h6>Recent searches</h6>
-      <ul className="list-group">
+      <ul className="list-inline">
         {history.map(term => {
           return <HistoryItem key={term} term={term}/>;
         })}

--- a/client/app/components/HistoryItem.jsx
+++ b/client/app/components/HistoryItem.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 
 const HistoryItem = ({ term, index }) => {
-  let element = '';
-
-  index === 0
-  ? element = <li className="list-inline-item">{term}</li>
-  : element = <li className="list-inline-item">&middot; {term}</li>;
+  let element = index === 0
+    ? <li className="list-inline-item">{term}</li>
+    : <li className="list-inline-item">&middot; {term}</li>;
 
   return element;
 };

--- a/client/app/components/HistoryItem.jsx
+++ b/client/app/components/HistoryItem.jsx
@@ -1,7 +1,13 @@
 import React from 'react';
 
-const HistoryItem = ({ term }) => (
-  <li className="list-inline-item">&middot; {term}</li>
-);
+const HistoryItem = ({ term, index }) => {
+  let element = '';
+
+  index === 0
+  ? element = <li className="list-inline-item">{term}</li>
+  : element = <li className="list-inline-item">&middot; {term}</li>;
+
+  return element;
+};
 
 export default HistoryItem;

--- a/client/app/components/HistoryItem.jsx
+++ b/client/app/components/HistoryItem.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const HistoryItem = ({ term }) => (
-  <li className="list-group-item">{term}</li>
+  <li className="list-inline-item">&middot; {term}</li>
 );
 
 export default HistoryItem;

--- a/client/app/components/Input.jsx
+++ b/client/app/components/Input.jsx
@@ -27,7 +27,7 @@ export default class Input extends React.Component {
 
   render () {
     return (
-      <div className="row">
+      <div className="row mb-4">
         <div className="col-12">
           <div className="input-group">
             <input

--- a/client/app/components/Layout.jsx
+++ b/client/app/components/Layout.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Body from './Body';
 import Footer from './Footer';
 import Header from './Header';
-import History from './History';
 
 const Layout = (props) => {
   return (
@@ -14,8 +13,8 @@ const Layout = (props) => {
             chartData={props.chartData}
             collectData={props.collectData}
             storyPoint={props.storyPoint}
+            history={props.history}
           />
-          <History history={props.history}/>
         </div>
       </div>
       <Footer/>

--- a/client/app/index.jsx
+++ b/client/app/index.jsx
@@ -27,7 +27,7 @@ class App extends React.Component {
 
   collectData(trend) {
     this.setState({
-      loader: <Loader color="#26A65B" size="16px" margin="4px"/>,
+      loader: <Loader color="#0275d8" size="16px" margin="4px"/>,
       storyPoint: {}
     });
     axios.get('/api/timeline', {


### PR DESCRIPTION
# Changes
1. Tweaks to search spinner (just a start)
1. Centered search history
1. Centered many things

# Search spinner

## Before
![search spinner](https://d2ppvlu71ri8gs.cloudfront.net/items/2Q3R20411G1S1e1J1Q0U/Screen%20Recording%202017-05-12%20at%2002.40%20PM.gif?v=a5a66b68)

## After
![search spinner](https://d2ppvlu71ri8gs.cloudfront.net/items/0B0I2e3n0v1K142v3X2P/Screen%20Recording%202017-05-12%20at%2002.40%20PM.gif?v=c329437c)

# Search page

## Before
![screencapture-trend-game-staging-herokuapp-1494625028447](https://cloud.githubusercontent.com/assets/892749/26017871/b23787da-3720-11e7-9435-7b1b769226f8.png)

## After
![screencapture-localhost-8080-1494625035582](https://cloud.githubusercontent.com/assets/892749/26017874/b5b75840-3720-11e7-8a80-78b7922b2308.png)

# Results page

## Before
![screencapture-trend-game-staging-herokuapp-1494625015730](https://cloud.githubusercontent.com/assets/892749/26017879/b9884d76-3720-11e7-90a2-e9c549705eca.png)

## After
![screencapture-localhost-8080-1494624978345](https://cloud.githubusercontent.com/assets/892749/26017886/be6dbf42-3720-11e7-9020-ab44f767340b.png)
