### PR TITLE
(feat) Clarify the purpose and content on page

### DIFF
--- a/client/app/components/Article.jsx
+++ b/client/app/components/Article.jsx
@@ -5,21 +5,21 @@ class Article extends React.Component {
     super(props);
     this.state = {
       media: this.props.story.media
-    }
+    };
   }
 
-  handleBrokenImage(event){
-    this.setState({media: ''})
+  handleBrokenImage(event) {
+    this.setState({media: ''});
   }
 
-  render(){
+  render() {
     return (
       <div className="col-12 col-lg-6">
         <div className="card">
           <img
             className="card-img-top img-fluid"
             src={this.state.media}
-            onError={(e)=>{this.handleBrokenImage(e)}}
+            onError={e => { this.handleBrokenImage(e); }}
           />
           <div className="card-block">
             <h4 className="card-title">{this.props.story.headline}</h4>
@@ -29,7 +29,7 @@ class Article extends React.Component {
         </div>
       </div>
     );
-  } 
-};
+  }
+}
 
 export default Article;

--- a/client/app/components/ArticleList.jsx
+++ b/client/app/components/ArticleList.jsx
@@ -15,7 +15,7 @@ const ArticleList = ({ trend, storyPoint }) => {
       <div className="row">
         <div className="col-12">
           <div className="row mb-4">
-            <div className="col-12"><h4>Top <span className="text-lowercase">"{trend}"</span> stories {storyPoint.formattedTime}</h4></div>
+            <div className="col-12"><h4>Here's why <em className="text-lowercase">{trend}</em> peaked</h4></div>
           </div>
           <div className="row">
             {storyPoint.stories.map(story => {

--- a/client/app/components/ArticleList.jsx
+++ b/client/app/components/ArticleList.jsx
@@ -15,7 +15,7 @@ const ArticleList = ({ trend, storyPoint }) => {
       <div className="row">
         <div className="col-12">
           <div className="row mb-4">
-            <div className="col-12"><h4>Here's why <em className="text-lowercase">{trend}</em> peaked</h4></div>
+            <div className="col-12"><h4><strong>Why</strong> did <strong className="text-lowercase">{trend}</strong> peak?</h4></div>
           </div>
           <div className="row">
             {storyPoint.stories.map(story => {

--- a/client/app/components/Chart.jsx
+++ b/client/app/components/Chart.jsx
@@ -10,7 +10,7 @@ const TrendChart = ({ chartData, storyPoint }) => {
     displayChart = (
       <span>
         <h4>
-          {`Popularity peaked on ${storyPoint.formattedAxisTime} for `}<span className="text-lowercase">"{trend}"</span>
+          Peak popularity for <em className="text-lowercase">{trend}:</em> {storyPoint.formattedAxisTime}
         </h4>
         <Chart
           chartType="LineChart"

--- a/client/app/components/Chart.jsx
+++ b/client/app/components/Chart.jsx
@@ -10,7 +10,7 @@ const TrendChart = ({ chartData, storyPoint }) => {
     displayChart = (
       <span>
         <h4>
-          Peak popularity for <em className="text-lowercase">{trend}:</em> {storyPoint.formattedAxisTime}
+          <strong>When</strong> did interest in <strong className="text-lowercase">{trend}</strong> peak? <strong>{storyPoint.formattedAxisTime}</strong>
         </h4>
         <Chart
           chartType="LineChart"

--- a/client/app/components/Header.jsx
+++ b/client/app/components/Header.jsx
@@ -4,8 +4,11 @@ export default class Header extends React.Component {
   render () {
     return (
       <div className="row">
-        <div className="col-12 mt-4 mb-4">
-          <h1 className="text-center">TrendGame</h1>
+        <div className="col-12 mt-4 mb-4 text-center">
+          <h1>TrendGame</h1>
+          <p className="text-muted">
+            Find out <strong>when</strong> interest in a topic peaked and <strong>why.</strong>
+          </p>
         </div>
       </div>
     );


### PR DESCRIPTION
# Problems
I was getting feedback that:

1. People did not understand what the graph was for
1. People assumed the news was a topical news search in general

# Proposals

1. Make a subhead under the title briefly setting expectations for what this app will offer (if anyone bothers to read it)
1. Re-write chart heading to lead with emphasis on topical peak
1. Re-write news heading to explain why we are showing the news 

# Side by side
![screen shot 2017-05-13 at 2 58 12 pm](https://cloud.githubusercontent.com/assets/892749/26029567/de52a8fa-37ec-11e7-852e-1461110873e4.png)

# Before
![screencapture-trend-game-herokuapp-1494712800696](https://cloud.githubusercontent.com/assets/892749/26029570/e5ad8eda-37ec-11e7-9295-13342740954f.png)

# After
![screencapture-localhost-8080-1494712789354](https://cloud.githubusercontent.com/assets/892749/26029571/ec712bfa-37ec-11e7-8e63-fb2705ea7519.png)
