### PR TITLE
(feat) Make card clickable and remove link

### DIFF
--- a/client/app/components/Article.jsx
+++ b/client/app/components/Article.jsx
@@ -15,18 +15,19 @@ class Article extends React.Component {
   render() {
     return (
       <div className="col-12 col-md-6">
-        <div className="card">
-          <img
-            className="card-img-top img-fluid"
-            src={this.state.media}
-            onError={e => { this.handleBrokenImage(e); }}
-          />
-          <div className="card-block">
-            <h4 className="card-title">{this.props.story.headline}</h4>
-            <p className="card-text">{this.props.story.summary}</p>
-            <a href={this.props.story.url} className="card-link">Read more</a>
+        <a href={this.props.story.url} className="card-clickable">
+          <div className="card">
+            <img
+              className="card-img-top img-fluid"
+              src={this.state.media}
+              onError={e => { this.handleBrokenImage(e); }}
+            />
+            <div className="card-block">
+              <h4 className="card-title">{this.props.story.headline}</h4>
+              <p className="card-text">{this.props.story.summary}</p>
+            </div>
           </div>
-        </div>
+        </a>
       </div>
     );
   }

--- a/client/public/styles.css
+++ b/client/public/styles.css
@@ -23,3 +23,17 @@ body {
 .card {
   margin-bottom: 30px;
 }
+
+a.card-clickable {
+  color: #292b2c;
+}
+
+a.card-clickable:hover {
+  text-decoration: none;
+}
+
+a.card-clickable:hover div.card {
+  border-color: #0275d8;
+  -webkit-transition: border-color ease-in-out .15s,-webkit-box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s,-webkit-box-shadow ease-in-out .15s;
+}

--- a/client/public/styles.css
+++ b/client/public/styles.css
@@ -28,7 +28,7 @@ a.card-clickable {
   color: #292b2c;
 }
 
-a.card-clickable:hover {
+a.card-clickable:hover, a.card-clickable:active {
   text-decoration: none;
 }
 


### PR DESCRIPTION
# Changes

1. **Remove** `Read more` link from the card content
1. **Allow** clicking (or tapping) anywhere on the card to visit the article

# Before
![before](https://d2ppvlu71ri8gs.cloudfront.net/items/073P3t1j2q3f2T3u1x1w/Screen%20Recording%202017-05-13%20at%2004.25%20PM.gif?v=b766b78d)

# After
![after](https://d2ppvlu71ri8gs.cloudfront.net/items/042T2d2b1W1u0N3p2c03/Screen%20Recording%202017-05-13%20at%2004.29%20PM.gif?v=0375e15a)