### PR TITLE
Feat/use html form to improve native device keyboards

### DIFF
--- a/client/app/components/Input.jsx
+++ b/client/app/components/Input.jsx
@@ -7,48 +7,42 @@ export default class Input extends React.Component {
       trend: ''
     };
     this.handeInput = this.handeInput.bind(this);
-    this.submitTrend = this.submitTrend.bind(this);
-    this.onEnter = this.onEnter.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
   }
 
   handeInput(event) {
     this.setState({trend: event.target.value});
   }
 
-  submitTrend(event) {
+  handleSubmit(e) {
+    e.preventDefault();
     this.props.collectData(this.state.trend);
-  }
-
-  onEnter(event) {
-    if (event.key === 'Enter') {
-      this.props.collectData(this.state.trend);
-    }
   }
 
   render () {
     return (
       <div className="row mb-4">
         <div className="col">
-          <div className="input-group">
-            <input
-              className="form-control"
-              type="text"
-              placeholder="Enter a topic"
-              onKeyPress={this.onEnter}
-              onChange={this.handeInput}
-              autoFocus
-            >
-            </input>
-            <span className="input-group-btn">
-              <button
-                className="btn btn-primary"
-                type="button"
-                onClick={this.submitTrend}
+          <form
+            action="submit"
+            onSubmit={e => { this.handleSubmit(e); }}
+          >
+            <div className="input-group">
+              <input
+                className="form-control search-input"
+                type="text"
+                placeholder="Enter a topic"
+                onChange={this.handeInput}
+                autoFocus
               >
-                Search
-              </button>
-            </span>
-          </div>
+              </input>
+              <span className="input-group-btn">
+                <button className="btn btn-primary" type="submit">
+                  Search
+                </button>
+              </span>
+            </div>
+          </form>
         </div>
       </div>
     );

--- a/client/app/components/Input.jsx
+++ b/client/app/components/Input.jsx
@@ -10,12 +10,13 @@ export default class Input extends React.Component {
     this.handleSubmit = this.handleSubmit.bind(this);
   }
 
-  handeInput(event) {
-    this.setState({trend: event.target.value});
+  handeInput(e) {
+    this.setState({trend: e.target.value});
   }
 
   handleSubmit(e) {
     e.preventDefault();
+    document.querySelector('.search-input').blur();
     this.props.collectData(this.state.trend);
   }
 
@@ -25,7 +26,7 @@ export default class Input extends React.Component {
         <div className="col">
           <form
             action="submit"
-            onSubmit={e => { this.handleSubmit(e); }}
+            onSubmit={this.handleSubmit}
           >
             <div className="input-group">
               <input


### PR DESCRIPTION
# Changes

1. Use default `form` tags for search input 
1. Default form with default `submit` event lets iOS keyboard show `"Go"` button
1. Refactor input search handler to use default form submit instead of `onKeypress` (return) or `onClick`
1. Trigger `blur` event on the input after submitting to dismiss keyboard `onSubmit`

# Search
## Before
![before form](https://d2ppvlu71ri8gs.cloudfront.net/items/1D0p3f2T133F2p0O3s2U/Screen%20Recording%202017-05-13%20at%2006.37%20PM.gif?v=dfe6a846)

## After
![after form](https://d2ppvlu71ri8gs.cloudfront.net/items/460s1O1W0O1h1F0E140L/Screen%20Recording%202017-05-13%20at%2006.38%20PM.gif?v=69199229)

# Error
## Before
![before error](https://d2ppvlu71ri8gs.cloudfront.net/items/0Z1i0K2e3i3W2L0l0Q2n/Screen%20Recording%202017-05-13%20at%2006.49%20PM.gif?v=08fa324d)

## After
![after error](https://d2ppvlu71ri8gs.cloudfront.net/items/1o2O1O343y2q0D0t3809/Screen%20Recording%202017-05-13%20at%2006.49%20PM.gif?v=7aeea113)



