### PR TITLE
(feat) Semantic header tags

### DIFF
--- a/client/app/components/Article.jsx
+++ b/client/app/components/Article.jsx
@@ -23,7 +23,7 @@ class Article extends React.Component {
               onError={e => { this.handleBrokenImage(e); }}
             />
             <div className="card-block">
-              <h4 className="card-title">{this.props.story.headline}</h4>
+              <h3 className="h4 card-title">{this.props.story.headline}</h3>
               <p className="card-text">{this.props.story.summary}</p>
             </div>
           </div>

--- a/client/app/components/ArticleList.jsx
+++ b/client/app/components/ArticleList.jsx
@@ -16,9 +16,9 @@ const ArticleList = ({ trend, storyPoint }) => {
         <div className="col">
           <div className="row mb-4">
             <div className="col">
-              <h4>
+              <h2 className="h4">
                 <strong>Why</strong> did <strong className="text-lowercase">{trend}</strong> peak?
-              </h4>
+              </h2>
             </div>
           </div>
           <div className="row">

--- a/client/app/components/Chart.jsx
+++ b/client/app/components/Chart.jsx
@@ -9,9 +9,9 @@ const TrendChart = ({ chartData, storyPoint }) => {
   } else {
     displayChart = (
       <span>
-        <h4>
+        <h2 className="h4">
           <strong>When</strong> did interest in <strong className="text-lowercase">{trend}</strong> peak? <strong>{storyPoint.formattedAxisTime}</strong>
-        </h4>
+        </h2>
         <Chart
           chartType="LineChart"
           data={data}


### PR DESCRIPTION
# Changes

1. Used hierarchical headers such that an outline could reasonably be made (with a screenreader for example) 
1. Applied classes to the headers to keep the styling as it was before

If you're wondering why the before and after images look the same it's because they're supposed to but they're actually before and after 💃 

# Before

![screencapture-localhost-8080-1494730789423](https://cloud.githubusercontent.com/assets/892749/26030918/da9ed51a-3816-11e7-821d-5d49dcb188a3.png)

# After

![screencapture-localhost-8080-1494730772533](https://cloud.githubusercontent.com/assets/892749/26030923/df34a0c8-3816-11e7-9f9d-80c45a733944.png)
