### PR TITLE
(refactor) Use default bootstrap viewport meta tag

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
     <link rel="stylesheet" href="./styles.css">
     <title>TrendGame data visualizer</title>


### PR DESCRIPTION
Earlier I rolled my own version of this `meta` tag `viewport` attribute to make it look decent on mobile, but I failed to see this default recommended tag by bootstrap so I'm updating to use theirs: https://v4-alpha.getbootstrap.com/getting-started/introduction/#responsive-meta-tag