### PR TITLE
Feat/backup search

### DIFF
--- a/tests/fixtures/stitched-timeline.js
+++ b/tests/fixtures/stitched-timeline.js
@@ -1,418 +1,421 @@
-module.exports = [
-  {
-    'date': 1454198400,
-    'formattedTime': 'Jan 31 - Feb 6 2016',
-    'formattedAxisTime': 'Jan 31, 2016',
-    'popularity': 33
-  },
-  {
-    'date': 1454803200,
-    'formattedTime': 'Feb 7 - Feb 13 2016',
-    'formattedAxisTime': 'Feb 7, 2016',
-    'popularity': 38
-  },
-  {
-    'date': 1455408000,
-    'formattedTime': 'Feb 14 - Feb 20 2016',
-    'formattedAxisTime': 'Feb 14, 2016',
-    'popularity': 34
-  },
-  {
-    'date': 1456012800,
-    'formattedTime': 'Feb 21 - Feb 27 2016',
-    'formattedAxisTime': 'Feb 21, 2016',
-    'popularity': 33
-  },
-  {
-    'date': 1456617600,
-    'formattedTime': 'Feb 28 - Mar 5 2016',
-    'formattedAxisTime': 'Feb 28, 2016',
-    'popularity': 33
-  },
-  {
-    'date': 1457222400,
-    'formattedTime': 'Mar 6 - Mar 12 2016',
-    'formattedAxisTime': 'Mar 6, 2016',
-    'popularity': 33
-  },
-  {
-    'date': 1457827200,
-    'formattedTime': 'Mar 13 - Mar 19 2016',
-    'formattedAxisTime': 'Mar 13, 2016',
-    'popularity': 35
-  },
-  {
-    'date': 1458432000,
-    'formattedTime': 'Mar 20 - Mar 26 2016',
-    'formattedAxisTime': 'Mar 20, 2016',
-    'popularity': 35
-  },
-  {
-    'date': 1459036800,
-    'formattedTime': 'Mar 27 - Apr 2 2016',
-    'formattedAxisTime': 'Mar 27, 2016',
-    'popularity': 36
-  },
-  {
-    'date': 1459641600,
-    'formattedTime': 'Apr 3 - Apr 9 2016',
-    'formattedAxisTime': 'Apr 3, 2016',
-    'popularity': 34
-  },
-  {
-    'date': 1460246400,
-    'formattedTime': 'Apr 10 - Apr 16 2016',
-    'formattedAxisTime': 'Apr 10, 2016',
-    'popularity': 38
-  },
-  {
-    'date': 1460851200,
-    'formattedTime': 'Apr 17 - Apr 23 2016',
-    'formattedAxisTime': 'Apr 17, 2016',
-    'popularity': 38
-  },
-  {
-    'date': 1461456000,
-    'formattedTime': 'Apr 24 - Apr 30 2016',
-    'formattedAxisTime': 'Apr 24, 2016',
-    'popularity': 38
-  },
-  {
-    'date': 1462060800,
-    'formattedTime': 'May 1 - May 7 2016',
-    'formattedAxisTime': 'May 1, 2016',
-    'popularity': 44
-  },
-  {
-    'date': 1462665600,
-    'formattedTime': 'May 8 - May 14 2016',
-    'formattedAxisTime': 'May 8, 2016',
-    'popularity': 52
-  },
-  {
-    'date': 1463270400,
-    'formattedTime': 'May 15 - May 21 2016',
-    'formattedAxisTime': 'May 15, 2016',
-    'popularity': 48
-  },
-  {
-    'date': 1463875200,
-    'formattedTime': 'May 22 - May 28 2016',
-    'formattedAxisTime': 'May 22, 2016',
-    'popularity': 62
-  },
-  {
-    'date': 1464480000,
-    'formattedTime': 'May 29 - Jun 4 2016',
-    'formattedAxisTime': 'May 29, 2016',
-    'popularity': 100,
-    'stories': [
-      {
-        headline: 'Clinton means continuity for US economy, Trump the unknown',
-        url: 'https://sg.news.yahoo.com/clinton-means-continuity-us-economy-trump-unknown-035116733.html',
-        media: 'https://s.yimg.com/uu/api/res/1.2/zXhKW.ZkLsbBHxj7yHyVLw--/aD01MTI7dz03Njg7c209MTthcHBpZD15dGFjaHlvbg--/http://media.zenfs.com/en_sg/News/AFP/a564487a19c3f06473de5b5802c81770b5f19040.jpg',
-        summary: 'Survey by the CNBC network of economists and Wall Street participants showed 46% feel Donald Trump would be better for the economy compared to 39% favoring Hillary Clinton\n\nOn taxes, public spending and protectionism the two candidates for the White House are diametrically opposed: Hillary Clinton represents continuity while Donald Trump seduces or frightens with his radical proposals.'
-      },
-      {
-        headline: 'Clinton leads Trump 48-43 percent in Washington Post - ABC tracking poll',
-        url: 'https://sg.news.yahoo.com/clinton-leads-trump-48-43-pct-washington-post-043905727.html',
-        media: 'https://s.yimg.com/ny/api/res/1.2/hmD7X8.fZspw61WBUzbvpQ--/YXBwaWQ9aGlnaGxhbmRlcjtzbT0xO3c9NDUwO2g9MzAwO2lsPXBsYW5l/http://media.zenfs.com/en_us/News/Reuters/2016-11-06T043905Z_1_LYNXMPECA5041_RTROPTP_2_USA-ELECTION-CLINTON.JPG.cf.jpg',
-        summary: 'U.S. Democratic presidential nominee Hillary Clinton rides an elevator with aides as she arrives for a campaign concert with Katy Perry in Philadelphia, Pennsylvania, U.S. November 5, 2016.'
-      },
-      {
-        headline: 'Clinton leads Trump 48-43 percent in Washington Post-ABC tracking poll',
-        url: 'http://news.yahoo.com/clinton-leads-trump-48-43-percent-washington-post-043628359.html',
-        media: 'https://s.yimg.com/os/mit/media/m/social/images/social_default_logo-1481777.png',
-        summary: 'U.S. presidential candidates Donald Trump and Hillary Clinton attend campaign rallies in Ambridge, Pennsylvania, October 10, 2016 and Manchester, New Hampshire U.S., October 24, 2016 in a combination of file photos.'
-      },
-      {
-        headline: 'Trump, Clinton take different strategies to shore up votes',
-        url: 'http://news.yahoo.com/trump-clinton-different-strategies-shore-votes-074124539--election.html',
-        media: 'https://s.yimg.com/uu/api/res/1.2/pGpymPAnre4DU70qrzucUQ--/aD0xMDgwO3c9MTkyMDtzbT0xO2FwcGlkPXl0YWNoeW9u/http://media.zenfs.com/en-US/video/video.associatedpressfree.com/0356d465b3c790fbd9745e29776ac563',
-        summary: 'Hillary Clinton is focusing her efforts in the campaign\'s final days on energizing voters who usually support the Democratic nominee, but may need an extra boost.'
-      }
-    ]
-  },
-  {
-    'date': 1465084800,
-    'formattedTime': 'Jun 5 - Jun 11 2016',
-    'formattedAxisTime': 'Jun 5, 2016',
-    'popularity': 96
-  },
-  {
-    'date': 1465689600,
-    'formattedTime': 'Jun 12 - Jun 18 2016',
-    'formattedAxisTime': 'Jun 12, 2016',
-    'popularity': 71
-  },
-  {
-    'date': 1466294400,
-    'formattedTime': 'Jun 19 - Jun 25 2016',
-    'formattedAxisTime': 'Jun 19, 2016',
-    'popularity': 56
-  },
-  {
-    'date': 1466899200,
-    'formattedTime': 'Jun 26 - Jul 2 2016',
-    'formattedAxisTime': 'Jun 26, 2016',
-    'popularity': 52
-  },
-  {
-    'date': 1467504000,
-    'formattedTime': 'Jul 3 - Jul 9 2016',
-    'formattedAxisTime': 'Jul 3, 2016',
-    'popularity': 48
-  },
-  {
-    'date': 1468108800,
-    'formattedTime': 'Jul 10 - Jul 16 2016',
-    'formattedAxisTime': 'Jul 10, 2016',
-    'popularity': 44
-  },
-  {
-    'date': 1468713600,
-    'formattedTime': 'Jul 17 - Jul 23 2016',
-    'formattedAxisTime': 'Jul 17, 2016',
-    'popularity': 42
-  },
-  {
-    'date': 1469318400,
-    'formattedTime': 'Jul 24 - Jul 30 2016',
-    'formattedAxisTime': 'Jul 24, 2016',
-    'popularity': 42
-  },
-  {
-    'date': 1469923200,
-    'formattedTime': 'Jul 31 - Aug 6 2016',
-    'formattedAxisTime': 'Jul 31, 2016',
-    'popularity': 40
-  },
-  {
-    'date': 1470528000,
-    'formattedTime': 'Aug 7 - Aug 13 2016',
-    'formattedAxisTime': 'Aug 7, 2016',
-    'popularity': 40
-  },
-  {
-    'date': 1471132800,
-    'formattedTime': 'Aug 14 - Aug 20 2016',
-    'formattedAxisTime': 'Aug 14, 2016',
-    'popularity': 40
-  },
-  {
-    'date': 1471737600,
-    'formattedTime': 'Aug 21 - Aug 27 2016',
-    'formattedAxisTime': 'Aug 21, 2016',
-    'popularity': 37
-  },
-  {
-    'date': 1472342400,
-    'formattedTime': 'Aug 28 - Sep 3 2016',
-    'formattedAxisTime': 'Aug 28, 2016',
-    'popularity': 49
-  },
-  {
-    'date': 1472947200,
-    'formattedTime': 'Sep 4 - Sep 10 2016',
-    'formattedAxisTime': 'Sep 4, 2016',
-    'popularity': 49
-  },
-  {
-    'date': 1473552000,
-    'formattedTime': 'Sep 11 - Sep 17 2016',
-    'formattedAxisTime': 'Sep 11, 2016',
-    'popularity': 46
-  },
-  {
-    'date': 1474156800,
-    'formattedTime': 'Sep 18 - Sep 24 2016',
-    'formattedAxisTime': 'Sep 18, 2016',
-    'popularity': 52
-  },
-  {
-    'date': 1474761600,
-    'formattedTime': 'Sep 25 - Oct 1 2016',
-    'formattedAxisTime': 'Sep 25, 2016',
-    'popularity': 43
-  },
-  {
-    'date': 1475366400,
-    'formattedTime': 'Oct 2 - Oct 8 2016',
-    'formattedAxisTime': 'Oct 2, 2016',
-    'popularity': 38
-  },
-  {
-    'date': 1475971200,
-    'formattedTime': 'Oct 9 - Oct 15 2016',
-    'formattedAxisTime': 'Oct 9, 2016',
-    'popularity': 37
-  },
-  {
-    'date': 1476576000,
-    'formattedTime': 'Oct 16 - Oct 22 2016',
-    'formattedAxisTime': 'Oct 16, 2016',
-    'popularity': 35
-  },
-  {
-    'date': 1477180800,
-    'formattedTime': 'Oct 23 - Oct 29 2016',
-    'formattedAxisTime': 'Oct 23, 2016',
-    'popularity': 37
-  },
-  {
-    'date': 1477785600,
-    'formattedTime': 'Oct 30 - Nov 5 2016',
-    'formattedAxisTime': 'Oct 30, 2016',
-    'popularity': 36
-  },
-  {
-    'date': 1478390400,
-    'formattedTime': 'Nov 6 - Nov 12 2016',
-    'formattedAxisTime': 'Nov 6, 2016',
-    'popularity': 31
-  },
-  {
-    'date': 1478995200,
-    'formattedTime': 'Nov 13 - Nov 19 2016',
-    'formattedAxisTime': 'Nov 13, 2016',
-    'popularity': 32
-  },
-  {
-    'date': 1479600000,
-    'formattedTime': 'Nov 20 - Nov 26 2016',
-    'formattedAxisTime': 'Nov 20, 2016',
-    'popularity': 32
-  },
-  {
-    'date': 1480204800,
-    'formattedTime': 'Nov 27 - Dec 3 2016',
-    'formattedAxisTime': 'Nov 27, 2016',
-    'popularity': 32
-  },
-  {
-    'date': 1480809600,
-    'formattedTime': 'Dec 4 - Dec 10 2016',
-    'formattedAxisTime': 'Dec 4, 2016',
-    'popularity': 33
-  },
-  {
-    'date': 1481414400,
-    'formattedTime': 'Dec 11 - Dec 17 2016',
-    'formattedAxisTime': 'Dec 11, 2016',
-    'popularity': 34
-  },
-  {
-    'date': 1482019200,
-    'formattedTime': 'Dec 18 - Dec 24 2016',
-    'formattedAxisTime': 'Dec 18, 2016',
-    'popularity': 33
-  },
-  {
-    'date': 1482624000,
-    'formattedTime': 'Dec 25 - Dec 31 2016',
-    'formattedAxisTime': 'Dec 25, 2016',
-    'popularity': 31
-  },
-  {
-    'date': 1483228800,
-    'formattedTime': 'Jan 1 - Jan 7 2017',
-    'formattedAxisTime': 'Jan 1, 2017',
-    'popularity': 31
-  },
-  {
-    'date': 1483833600,
-    'formattedTime': 'Jan 8 - Jan 14 2017',
-    'formattedAxisTime': 'Jan 8, 2017',
-    'popularity': 29
-  },
-  {
-    'date': 1484438400,
-    'formattedTime': 'Jan 15 - Jan 21 2017',
-    'formattedAxisTime': 'Jan 15, 2017',
-    'popularity': 28
-  },
-  {
-    'date': 1485043200,
-    'formattedTime': 'Jan 22 - Jan 28 2017',
-    'formattedAxisTime': 'Jan 22, 2017',
-    'popularity': 28
-  },
-  {
-    'date': 1485648000,
-    'formattedTime': 'Jan 29 - Feb 4 2017',
-    'formattedAxisTime': 'Jan 29, 2017',
-    'popularity': 28
-  },
-  {
-    'date': 1486252800,
-    'formattedTime': 'Feb 5 - Feb 11 2017',
-    'formattedAxisTime': 'Feb 5, 2017',
-    'popularity': 29
-  },
-  {
-    'date': 1486857600,
-    'formattedTime': 'Feb 12 - Feb 18 2017',
-    'formattedAxisTime': 'Feb 12, 2017',
-    'popularity': 30
-  },
-  {
-    'date': 1487462400,
-    'formattedTime': 'Feb 19 - Feb 25 2017',
-    'formattedAxisTime': 'Feb 19, 2017',
-    'popularity': 32
-  },
-  {
-    'date': 1488067200,
-    'formattedTime': 'Feb 26 - Mar 4 2017',
-    'formattedAxisTime': 'Feb 26, 2017',
-    'popularity': 33
-  },
-  {
-    'date': 1488672000,
-    'formattedTime': 'Mar 5 - Mar 11 2017',
-    'formattedAxisTime': 'Mar 5, 2017',
-    'popularity': 31
-  },
-  {
-    'date': 1489276800,
-    'formattedTime': 'Mar 12 - Mar 18 2017',
-    'formattedAxisTime': 'Mar 12, 2017',
-    'popularity': 30
-  },
-  {
-    'date': 1489881600,
-    'formattedTime': 'Mar 19 - Mar 25 2017',
-    'formattedAxisTime': 'Mar 19, 2017',
-    'popularity': 31
-  },
-  {
-    'date': 1490486400,
-    'formattedTime': 'Mar 26 - Apr 1 2017',
-    'formattedAxisTime': 'Mar 26, 2017',
-    'popularity': 32
-  },
-  {
-    'date': 1491091200,
-    'formattedTime': 'Apr 2 - Apr 8 2017',
-    'formattedAxisTime': 'Apr 2, 2017',
-    'popularity': 30
-  },
-  {
-    'date': 1491696000,
-    'formattedTime': 'Apr 9 - Apr 15 2017',
-    'formattedAxisTime': 'Apr 9, 2017',
-    'popularity': 30
-  },
-  {
-    'date': 1492300800,
-    'formattedTime': 'Apr 16 - Apr 22 2017',
-    'formattedAxisTime': 'Apr 16, 2017',
-    'popularity': 30
-  },
-  {
-    'date': 1492905600,
-    'formattedTime': 'Apr 23 - Apr 29 2017',
-    'formattedAxisTime': 'Apr 23, 2017',
-    'popularity': 31
-  }
-];
+module.exports = {
+  trend: 'clinton',
+  timeline: [
+    {
+      'date': 1454198400,
+      'formattedTime': 'Jan 31 - Feb 6 2016',
+      'formattedAxisTime': 'Jan 31, 2016',
+      'popularity': 33
+    },
+    {
+      'date': 1454803200,
+      'formattedTime': 'Feb 7 - Feb 13 2016',
+      'formattedAxisTime': 'Feb 7, 2016',
+      'popularity': 38
+    },
+    {
+      'date': 1455408000,
+      'formattedTime': 'Feb 14 - Feb 20 2016',
+      'formattedAxisTime': 'Feb 14, 2016',
+      'popularity': 34
+    },
+    {
+      'date': 1456012800,
+      'formattedTime': 'Feb 21 - Feb 27 2016',
+      'formattedAxisTime': 'Feb 21, 2016',
+      'popularity': 33
+    },
+    {
+      'date': 1456617600,
+      'formattedTime': 'Feb 28 - Mar 5 2016',
+      'formattedAxisTime': 'Feb 28, 2016',
+      'popularity': 33
+    },
+    {
+      'date': 1457222400,
+      'formattedTime': 'Mar 6 - Mar 12 2016',
+      'formattedAxisTime': 'Mar 6, 2016',
+      'popularity': 33
+    },
+    {
+      'date': 1457827200,
+      'formattedTime': 'Mar 13 - Mar 19 2016',
+      'formattedAxisTime': 'Mar 13, 2016',
+      'popularity': 35
+    },
+    {
+      'date': 1458432000,
+      'formattedTime': 'Mar 20 - Mar 26 2016',
+      'formattedAxisTime': 'Mar 20, 2016',
+      'popularity': 35
+    },
+    {
+      'date': 1459036800,
+      'formattedTime': 'Mar 27 - Apr 2 2016',
+      'formattedAxisTime': 'Mar 27, 2016',
+      'popularity': 36
+    },
+    {
+      'date': 1459641600,
+      'formattedTime': 'Apr 3 - Apr 9 2016',
+      'formattedAxisTime': 'Apr 3, 2016',
+      'popularity': 34
+    },
+    {
+      'date': 1460246400,
+      'formattedTime': 'Apr 10 - Apr 16 2016',
+      'formattedAxisTime': 'Apr 10, 2016',
+      'popularity': 38
+    },
+    {
+      'date': 1460851200,
+      'formattedTime': 'Apr 17 - Apr 23 2016',
+      'formattedAxisTime': 'Apr 17, 2016',
+      'popularity': 38
+    },
+    {
+      'date': 1461456000,
+      'formattedTime': 'Apr 24 - Apr 30 2016',
+      'formattedAxisTime': 'Apr 24, 2016',
+      'popularity': 38
+    },
+    {
+      'date': 1462060800,
+      'formattedTime': 'May 1 - May 7 2016',
+      'formattedAxisTime': 'May 1, 2016',
+      'popularity': 44
+    },
+    {
+      'date': 1462665600,
+      'formattedTime': 'May 8 - May 14 2016',
+      'formattedAxisTime': 'May 8, 2016',
+      'popularity': 52
+    },
+    {
+      'date': 1463270400,
+      'formattedTime': 'May 15 - May 21 2016',
+      'formattedAxisTime': 'May 15, 2016',
+      'popularity': 48
+    },
+    {
+      'date': 1463875200,
+      'formattedTime': 'May 22 - May 28 2016',
+      'formattedAxisTime': 'May 22, 2016',
+      'popularity': 62
+    },
+    {
+      'date': 1464480000,
+      'formattedTime': 'May 29 - Jun 4 2016',
+      'formattedAxisTime': 'May 29, 2016',
+      'popularity': 100,
+      'stories': [
+        {
+          headline: 'Clinton means continuity for US economy, Trump the unknown',
+          url: 'https://sg.news.yahoo.com/clinton-means-continuity-us-economy-trump-unknown-035116733.html',
+          media: 'https://s.yimg.com/uu/api/res/1.2/zXhKW.ZkLsbBHxj7yHyVLw--/aD01MTI7dz03Njg7c209MTthcHBpZD15dGFjaHlvbg--/http://media.zenfs.com/en_sg/News/AFP/a564487a19c3f06473de5b5802c81770b5f19040.jpg',
+          summary: 'Survey by the CNBC network of economists and Wall Street participants showed 46% feel Donald Trump would be better for the economy compared to 39% favoring Hillary Clinton\n\nOn taxes, public spending and protectionism the two candidates for the White House are diametrically opposed: Hillary Clinton represents continuity while Donald Trump seduces or frightens with his radical proposals.'
+        },
+        {
+          headline: 'Clinton leads Trump 48-43 percent in Washington Post - ABC tracking poll',
+          url: 'https://sg.news.yahoo.com/clinton-leads-trump-48-43-pct-washington-post-043905727.html',
+          media: 'https://s.yimg.com/ny/api/res/1.2/hmD7X8.fZspw61WBUzbvpQ--/YXBwaWQ9aGlnaGxhbmRlcjtzbT0xO3c9NDUwO2g9MzAwO2lsPXBsYW5l/http://media.zenfs.com/en_us/News/Reuters/2016-11-06T043905Z_1_LYNXMPECA5041_RTROPTP_2_USA-ELECTION-CLINTON.JPG.cf.jpg',
+          summary: 'U.S. Democratic presidential nominee Hillary Clinton rides an elevator with aides as she arrives for a campaign concert with Katy Perry in Philadelphia, Pennsylvania, U.S. November 5, 2016.'
+        },
+        {
+          headline: 'Clinton leads Trump 48-43 percent in Washington Post-ABC tracking poll',
+          url: 'http://news.yahoo.com/clinton-leads-trump-48-43-percent-washington-post-043628359.html',
+          media: 'https://s.yimg.com/os/mit/media/m/social/images/social_default_logo-1481777.png',
+          summary: 'U.S. presidential candidates Donald Trump and Hillary Clinton attend campaign rallies in Ambridge, Pennsylvania, October 10, 2016 and Manchester, New Hampshire U.S., October 24, 2016 in a combination of file photos.'
+        },
+        {
+          headline: 'Trump, Clinton take different strategies to shore up votes',
+          url: 'http://news.yahoo.com/trump-clinton-different-strategies-shore-votes-074124539--election.html',
+          media: 'https://s.yimg.com/uu/api/res/1.2/pGpymPAnre4DU70qrzucUQ--/aD0xMDgwO3c9MTkyMDtzbT0xO2FwcGlkPXl0YWNoeW9u/http://media.zenfs.com/en-US/video/video.associatedpressfree.com/0356d465b3c790fbd9745e29776ac563',
+          summary: 'Hillary Clinton is focusing her efforts in the campaign\'s final days on energizing voters who usually support the Democratic nominee, but may need an extra boost.'
+        }
+      ]
+    },
+    {
+      'date': 1465084800,
+      'formattedTime': 'Jun 5 - Jun 11 2016',
+      'formattedAxisTime': 'Jun 5, 2016',
+      'popularity': 96
+    },
+    {
+      'date': 1465689600,
+      'formattedTime': 'Jun 12 - Jun 18 2016',
+      'formattedAxisTime': 'Jun 12, 2016',
+      'popularity': 71
+    },
+    {
+      'date': 1466294400,
+      'formattedTime': 'Jun 19 - Jun 25 2016',
+      'formattedAxisTime': 'Jun 19, 2016',
+      'popularity': 56
+    },
+    {
+      'date': 1466899200,
+      'formattedTime': 'Jun 26 - Jul 2 2016',
+      'formattedAxisTime': 'Jun 26, 2016',
+      'popularity': 52
+    },
+    {
+      'date': 1467504000,
+      'formattedTime': 'Jul 3 - Jul 9 2016',
+      'formattedAxisTime': 'Jul 3, 2016',
+      'popularity': 48
+    },
+    {
+      'date': 1468108800,
+      'formattedTime': 'Jul 10 - Jul 16 2016',
+      'formattedAxisTime': 'Jul 10, 2016',
+      'popularity': 44
+    },
+    {
+      'date': 1468713600,
+      'formattedTime': 'Jul 17 - Jul 23 2016',
+      'formattedAxisTime': 'Jul 17, 2016',
+      'popularity': 42
+    },
+    {
+      'date': 1469318400,
+      'formattedTime': 'Jul 24 - Jul 30 2016',
+      'formattedAxisTime': 'Jul 24, 2016',
+      'popularity': 42
+    },
+    {
+      'date': 1469923200,
+      'formattedTime': 'Jul 31 - Aug 6 2016',
+      'formattedAxisTime': 'Jul 31, 2016',
+      'popularity': 40
+    },
+    {
+      'date': 1470528000,
+      'formattedTime': 'Aug 7 - Aug 13 2016',
+      'formattedAxisTime': 'Aug 7, 2016',
+      'popularity': 40
+    },
+    {
+      'date': 1471132800,
+      'formattedTime': 'Aug 14 - Aug 20 2016',
+      'formattedAxisTime': 'Aug 14, 2016',
+      'popularity': 40
+    },
+    {
+      'date': 1471737600,
+      'formattedTime': 'Aug 21 - Aug 27 2016',
+      'formattedAxisTime': 'Aug 21, 2016',
+      'popularity': 37
+    },
+    {
+      'date': 1472342400,
+      'formattedTime': 'Aug 28 - Sep 3 2016',
+      'formattedAxisTime': 'Aug 28, 2016',
+      'popularity': 49
+    },
+    {
+      'date': 1472947200,
+      'formattedTime': 'Sep 4 - Sep 10 2016',
+      'formattedAxisTime': 'Sep 4, 2016',
+      'popularity': 49
+    },
+    {
+      'date': 1473552000,
+      'formattedTime': 'Sep 11 - Sep 17 2016',
+      'formattedAxisTime': 'Sep 11, 2016',
+      'popularity': 46
+    },
+    {
+      'date': 1474156800,
+      'formattedTime': 'Sep 18 - Sep 24 2016',
+      'formattedAxisTime': 'Sep 18, 2016',
+      'popularity': 52
+    },
+    {
+      'date': 1474761600,
+      'formattedTime': 'Sep 25 - Oct 1 2016',
+      'formattedAxisTime': 'Sep 25, 2016',
+      'popularity': 43
+    },
+    {
+      'date': 1475366400,
+      'formattedTime': 'Oct 2 - Oct 8 2016',
+      'formattedAxisTime': 'Oct 2, 2016',
+      'popularity': 38
+    },
+    {
+      'date': 1475971200,
+      'formattedTime': 'Oct 9 - Oct 15 2016',
+      'formattedAxisTime': 'Oct 9, 2016',
+      'popularity': 37
+    },
+    {
+      'date': 1476576000,
+      'formattedTime': 'Oct 16 - Oct 22 2016',
+      'formattedAxisTime': 'Oct 16, 2016',
+      'popularity': 35
+    },
+    {
+      'date': 1477180800,
+      'formattedTime': 'Oct 23 - Oct 29 2016',
+      'formattedAxisTime': 'Oct 23, 2016',
+      'popularity': 37
+    },
+    {
+      'date': 1477785600,
+      'formattedTime': 'Oct 30 - Nov 5 2016',
+      'formattedAxisTime': 'Oct 30, 2016',
+      'popularity': 36
+    },
+    {
+      'date': 1478390400,
+      'formattedTime': 'Nov 6 - Nov 12 2016',
+      'formattedAxisTime': 'Nov 6, 2016',
+      'popularity': 31
+    },
+    {
+      'date': 1478995200,
+      'formattedTime': 'Nov 13 - Nov 19 2016',
+      'formattedAxisTime': 'Nov 13, 2016',
+      'popularity': 32
+    },
+    {
+      'date': 1479600000,
+      'formattedTime': 'Nov 20 - Nov 26 2016',
+      'formattedAxisTime': 'Nov 20, 2016',
+      'popularity': 32
+    },
+    {
+      'date': 1480204800,
+      'formattedTime': 'Nov 27 - Dec 3 2016',
+      'formattedAxisTime': 'Nov 27, 2016',
+      'popularity': 32
+    },
+    {
+      'date': 1480809600,
+      'formattedTime': 'Dec 4 - Dec 10 2016',
+      'formattedAxisTime': 'Dec 4, 2016',
+      'popularity': 33
+    },
+    {
+      'date': 1481414400,
+      'formattedTime': 'Dec 11 - Dec 17 2016',
+      'formattedAxisTime': 'Dec 11, 2016',
+      'popularity': 34
+    },
+    {
+      'date': 1482019200,
+      'formattedTime': 'Dec 18 - Dec 24 2016',
+      'formattedAxisTime': 'Dec 18, 2016',
+      'popularity': 33
+    },
+    {
+      'date': 1482624000,
+      'formattedTime': 'Dec 25 - Dec 31 2016',
+      'formattedAxisTime': 'Dec 25, 2016',
+      'popularity': 31
+    },
+    {
+      'date': 1483228800,
+      'formattedTime': 'Jan 1 - Jan 7 2017',
+      'formattedAxisTime': 'Jan 1, 2017',
+      'popularity': 31
+    },
+    {
+      'date': 1483833600,
+      'formattedTime': 'Jan 8 - Jan 14 2017',
+      'formattedAxisTime': 'Jan 8, 2017',
+      'popularity': 29
+    },
+    {
+      'date': 1484438400,
+      'formattedTime': 'Jan 15 - Jan 21 2017',
+      'formattedAxisTime': 'Jan 15, 2017',
+      'popularity': 28
+    },
+    {
+      'date': 1485043200,
+      'formattedTime': 'Jan 22 - Jan 28 2017',
+      'formattedAxisTime': 'Jan 22, 2017',
+      'popularity': 28
+    },
+    {
+      'date': 1485648000,
+      'formattedTime': 'Jan 29 - Feb 4 2017',
+      'formattedAxisTime': 'Jan 29, 2017',
+      'popularity': 28
+    },
+    {
+      'date': 1486252800,
+      'formattedTime': 'Feb 5 - Feb 11 2017',
+      'formattedAxisTime': 'Feb 5, 2017',
+      'popularity': 29
+    },
+    {
+      'date': 1486857600,
+      'formattedTime': 'Feb 12 - Feb 18 2017',
+      'formattedAxisTime': 'Feb 12, 2017',
+      'popularity': 30
+    },
+    {
+      'date': 1487462400,
+      'formattedTime': 'Feb 19 - Feb 25 2017',
+      'formattedAxisTime': 'Feb 19, 2017',
+      'popularity': 32
+    },
+    {
+      'date': 1488067200,
+      'formattedTime': 'Feb 26 - Mar 4 2017',
+      'formattedAxisTime': 'Feb 26, 2017',
+      'popularity': 33
+    },
+    {
+      'date': 1488672000,
+      'formattedTime': 'Mar 5 - Mar 11 2017',
+      'formattedAxisTime': 'Mar 5, 2017',
+      'popularity': 31
+    },
+    {
+      'date': 1489276800,
+      'formattedTime': 'Mar 12 - Mar 18 2017',
+      'formattedAxisTime': 'Mar 12, 2017',
+      'popularity': 30
+    },
+    {
+      'date': 1489881600,
+      'formattedTime': 'Mar 19 - Mar 25 2017',
+      'formattedAxisTime': 'Mar 19, 2017',
+      'popularity': 31
+    },
+    {
+      'date': 1490486400,
+      'formattedTime': 'Mar 26 - Apr 1 2017',
+      'formattedAxisTime': 'Mar 26, 2017',
+      'popularity': 32
+    },
+    {
+      'date': 1491091200,
+      'formattedTime': 'Apr 2 - Apr 8 2017',
+      'formattedAxisTime': 'Apr 2, 2017',
+      'popularity': 30
+    },
+    {
+      'date': 1491696000,
+      'formattedTime': 'Apr 9 - Apr 15 2017',
+      'formattedAxisTime': 'Apr 9, 2017',
+      'popularity': 30
+    },
+    {
+      'date': 1492300800,
+      'formattedTime': 'Apr 16 - Apr 22 2017',
+      'formattedAxisTime': 'Apr 16, 2017',
+      'popularity': 30
+    },
+    {
+      'date': 1492905600,
+      'formattedTime': 'Apr 23 - Apr 29 2017',
+      'formattedAxisTime': 'Apr 23, 2017',
+      'popularity': 31
+    }
+  ]
+};

--- a/tests/stitchData.spec.js
+++ b/tests/stitchData.spec.js
@@ -9,7 +9,7 @@ const timeline = require('./fixtures/stitched-timeline');
 describe('Stitching timeline to make final data', function() {
   it('should merge trend query and news data on matching dates', function() {
     const expected = timeline;
-    const actual = stitchTimeline(trends, stories);
+    const actual = stitchTimeline(trends, stories, '"clinton"');
     expect(actual).to.deep.equal(expected);
   });
 });

--- a/utilities/aylienApi.js
+++ b/utilities/aylienApi.js
@@ -3,7 +3,7 @@ const epoch = require('epoch.js');
 
 const formatStories = require('./aylienApiDataFormatter');
 
-const getStories = (queryString, peaks, callback) => {
+const getStories = (queryString, peaks, scope, callback) => {
 
   // Format date query for API
   // 604800000 is 1 week in milliseconds
@@ -37,13 +37,14 @@ const getStories = (queryString, peaks, callback) => {
   }
 
   // Assign options for API query
-  const opts = {
-    'title': queryString,
+  let opts = {
     'sortBy': 'source.links_in_count',
     'language': ['en'],
     'publishedAtStart': formattedPeakDate,
     'publishedAtEnd': formattedPeakEndDate,
   };
+
+  opts[scope] = queryString;
 
   apiInstance.listStories(opts, (error, data, response) => {
     if (error) {

--- a/utilities/makeTimeline.js
+++ b/utilities/makeTimeline.js
@@ -10,7 +10,7 @@ const makeTimeline = (searchString, callback) => {
     } else {
       const peaks = findPeaks(timeSeries);
 
-      getNews(searchString, peaks, (err, peakStories) => {
+      getNews(searchString, peaks, 'title', (err, peakStories) => {
         if (err) {
           callback(err, null);
         } else {

--- a/utilities/makeTimeline.js
+++ b/utilities/makeTimeline.js
@@ -7,12 +7,31 @@ const makeTimeline = (searchString, callback) => {
   queryTrend(searchString, (err, timeSeries) => {
     if (err) {
       callback(err, null);
+
     } else {
       const peaks = findPeaks(timeSeries);
 
       getNews(searchString, peaks, 'title', (err, peakStories) => {
         if (err) {
           callback(err, null);
+
+        } else if (peakStories[0].stories[0] === undefined) {
+          getNews(searchString, peaks, 'body', (err, peakStories) => {
+
+            if (err) {
+              callback(err, null);
+            } else {
+              const timeline = makeFinalData(timeSeries, peakStories);
+
+              const response = {
+                timeline: timeline,
+                trend: searchString.slice(1, -1)
+              };
+
+              callback(null, response);
+            }
+          });
+
         } else {
           const timeline = makeFinalData(timeSeries, peakStories);
 

--- a/utilities/makeTimeline.js
+++ b/utilities/makeTimeline.js
@@ -21,25 +21,13 @@ const makeTimeline = (searchString, callback) => {
             if (err) {
               callback(err, null);
             } else {
-              const timeline = makeFinalData(timeSeries, peakStories);
-
-              const response = {
-                timeline: timeline,
-                trend: searchString.slice(1, -1)
-              };
-
+              const response = makeFinalData(timeSeries, peakStories, searchString);
               callback(null, response);
             }
           });
 
         } else {
-          const timeline = makeFinalData(timeSeries, peakStories);
-
-          const response = {
-            timeline: timeline,
-            trend: searchString.slice(1, -1)
-          };
-
+          const response = makeFinalData(timeSeries, peakStories, searchString);
           callback(null, response);
         }
       });

--- a/utilities/stitchData.js
+++ b/utilities/stitchData.js
@@ -1,4 +1,4 @@
-module.exports = (timeline, stories) => {
+const makeTimeline = (timeline, stories) => {
   const timelineDates = timeline.map(point => point.date);
 
   if (timeline.length === 0) {
@@ -16,3 +16,16 @@ module.exports = (timeline, stories) => {
 
   return timeline;
 };
+
+const makeResponse = (timeSeries, peakStories, searchString) => {
+  const timeline = makeTimeline(timeSeries, peakStories);
+
+  const response = {
+    timeline: timeline,
+    trend: searchString.slice(1, -1)
+  };
+
+  return response;
+};
+
+module.exports = makeResponse;


### PR DESCRIPTION
tl;dr: If the initial aylien api search doesn't find any stories, we launch a second search that looks for the term in the bodies of news stories.

aylienApi: Adds a parameter for the scope of the search.

makeTimline: Nests an additional call to the aylien API if we don't find anything on the first query.

stitchData: with the second search I was beginning to repeat myself.  Moved more code into stitchData to improve DRY.

tests: refactored to test for the new functionality